### PR TITLE
feat: AIプロバイダー選択UIを追加 (Issue #52)

### DIFF
--- a/app/routes/menu.py
+++ b/app/routes/menu.py
@@ -18,7 +18,7 @@ from PIL import Image
 from werkzeug.datastructures import FileStorage
 
 from app.services.ai.base import AIProviderError, InvalidMenuImageError
-from app.services.ai.factory import AIProviderFactory
+from app.services.ai.factory import AIProviderFactory, UnknownProviderError
 from app.translations.loader import TranslationLoader
 
 # Logger setup
@@ -194,10 +194,18 @@ def analyze_menu() -> Response:
         # Validation confirmed that content_type is in ALLOWED_MIME_TYPES
         mime_type = file.content_type
 
-        logger.info(f"Processing image: {file.filename}, size: {len(image_data)} bytes, MIME: {mime_type}, Language: {language}")
+        # Get AI provider from header (default: claude)
+        provider_name = request.headers.get("X-AI-Provider", "claude")
+
+        logger.info(
+            f"Processing image: {file.filename}, size: {len(image_data)} bytes, "
+            f"MIME: {mime_type}, Language: {language}, Provider: {provider_name}"
+        )
 
         # Get AI provider with language support
-        provider = AIProviderFactory.create(api_key=api_key, language=language)
+        provider = AIProviderFactory.create(
+            api_key=api_key, provider_name=provider_name, language=language
+        )
 
         # Analyze menu
         result = provider.analyze_menu(image_data, mime_type)
@@ -223,6 +231,21 @@ def analyze_menu() -> Response:
 
         return jsonify(response_data), 200
 
+    except UnknownProviderError as e:
+        logger.warning(f"Unknown provider requested: {e}")
+        default_msg = "This provider is not yet implemented."
+        error_msg = TranslationLoader.get(
+            language, 'api_key_modal.provider_not_implemented', default_msg
+        )
+        title_msg = TranslationLoader.get(
+            language, 'error.provider_not_implemented', 'Provider Not Implemented'
+        )
+        return _create_error_response(
+            error_message=error_msg,
+            error_code="PROVIDER_NOT_IMPLEMENTED",
+            status_code=400,
+            title=title_msg,
+        )
     except InvalidMenuImageError as e:
         logger.warning(f"Invalid menu image: {e}")
         error_msg = str(e) if str(e) else TranslationLoader.get(language, 'toast.analysis_failed', 'Analysis failed')

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -325,6 +325,16 @@ function uploadZone() {
 // グローバルに公開
 window.uploadZone = uploadZone;
 
+// 利用可能なAIプロバイダー定義
+const AI_PROVIDERS = [
+    { id: 'claude', name: 'Claude (Anthropic)', implemented: true },
+    { id: 'openai', name: 'OpenAI GPT-4V', implemented: false },
+    { id: 'gemini', name: 'Google Gemini', implemented: false }
+];
+
+// デフォルトのプロバイダー
+const DEFAULT_PROVIDER = 'claude';
+
 /**
  * APIキー設定管理のAlpine.jsコンポーネント
  * @returns {Object} Alpine.jsコンポーネントオブジェクト
@@ -334,7 +344,13 @@ function apiKeyManager() {
         // モーダル表示状態
         showModal: false,
 
-        // APIキー
+        // 選択中のプロバイダー
+        selectedProvider: DEFAULT_PROVIDER,
+
+        // プロバイダーごとのAPIキー
+        apiKeys: {},
+
+        // 現在のプロバイダーのAPIキー（後方互換性のため）
         apiKey: '',
 
         // APIキー入力フィールド（マスク用）
@@ -343,10 +359,13 @@ function apiKeyManager() {
         // APIキーの表示/非表示
         showApiKey: false,
 
+        // 利用可能なプロバイダー一覧
+        providers: AI_PROVIDERS,
+
         // 初期化
         init() {
-            // localStorageからAPIキーを読み込み
-            this.apiKey = this.getStoredApiKey();
+            // localStorageから設定を読み込み
+            this.loadSettings();
 
             // APIキーが未設定の場合、モーダルを表示
             if (!this.apiKey) {
@@ -361,16 +380,102 @@ function apiKeyManager() {
         },
 
         /**
-         * localStorageからAPIキーを取得
+         * localStorageから設定を読み込み
+         */
+        loadSettings() {
+            try {
+                // プロバイダーを読み込み
+                const storedProvider = localStorage.getItem('menu_judge_provider');
+                if (storedProvider && AI_PROVIDERS.some(p => p.id === storedProvider)) {
+                    this.selectedProvider = storedProvider;
+                }
+
+                // 各プロバイダーのAPIキーを読み込み
+                AI_PROVIDERS.forEach(provider => {
+                    const key = localStorage.getItem(`menu_judge_api_key_${provider.id}`) || '';
+                    this.apiKeys[provider.id] = key;
+                });
+
+                // 後方互換性: 古い形式のAPIキーがある場合はClaudeに移行
+                const legacyKey = localStorage.getItem('menu_judge_api_key');
+                if (legacyKey && !this.apiKeys.claude) {
+                    this.apiKeys.claude = legacyKey;
+                    localStorage.setItem('menu_judge_api_key_claude', legacyKey);
+                    localStorage.removeItem('menu_judge_api_key');
+                }
+
+                // 現在のプロバイダーのAPIキーを設定
+                this.apiKey = this.apiKeys[this.selectedProvider] || '';
+            } catch (e) {
+                console.error('Failed to load settings from localStorage:', e);
+                this.apiKey = '';
+            }
+        },
+
+        /**
+         * 現在選択中のプロバイダーのAPIキーを取得
          * @returns {string} APIキー（未設定の場合は空文字列）
          */
         getStoredApiKey() {
+            return this.apiKeys[this.selectedProvider] || '';
+        },
+
+        /**
+         * プロバイダーが実装済みかどうかを確認
+         * @param {string} providerId - プロバイダーID
+         * @returns {boolean} 実装済みならtrue
+         */
+        isProviderImplemented(providerId) {
+            const provider = AI_PROVIDERS.find(p => p.id === providerId);
+            return provider ? provider.implemented : false;
+        },
+
+        /**
+         * プロバイダーを変更
+         * @param {string} providerId - 新しいプロバイダーID
+         */
+        changeProvider(providerId) {
+            this.selectedProvider = providerId;
+            this.apiKey = this.apiKeys[providerId] || '';
+            this.apiKeyInput = this.apiKey;
+
+            // localStorageに保存
             try {
-                return localStorage.getItem('menu_judge_api_key') || '';
+                localStorage.setItem('menu_judge_provider', providerId);
             } catch (e) {
-                console.error('Failed to load API key from localStorage:', e);
-                return '';
+                console.error('Failed to save provider:', e);
             }
+
+            // HTMXヘッダーを更新
+            this.setupHtmxHeaders();
+        },
+
+        /**
+         * プロバイダーのコンソールURLを取得
+         * @param {string} providerId - プロバイダーID
+         * @returns {string} コンソールURL
+         */
+        getProviderConsoleUrl(providerId) {
+            const urls = {
+                claude: 'https://console.anthropic.com/settings/keys',
+                openai: 'https://platform.openai.com/api-keys',
+                gemini: 'https://aistudio.google.com/app/apikey'
+            };
+            return urls[providerId] || urls.claude;
+        },
+
+        /**
+         * プロバイダーのプレースホルダーを取得
+         * @param {string} providerId - プロバイダーID
+         * @returns {string} プレースホルダーテキスト
+         */
+        getProviderPlaceholder(providerId) {
+            const placeholders = {
+                claude: 'sk-ant-api03-...',
+                openai: 'sk-proj-...',
+                gemini: 'AIza...'
+            };
+            return placeholders[providerId] || '';
         },
 
         /**
@@ -380,8 +485,20 @@ function apiKeyManager() {
         saveApiKey(key) {
             try {
                 if (key && key.trim()) {
-                    localStorage.setItem('menu_judge_api_key', key.trim());
-                    this.apiKey = key.trim();
+                    const trimmedKey = key.trim();
+
+                    // 未実装プロバイダーの警告
+                    if (!this.isProviderImplemented(this.selectedProvider)) {
+                        showToast(t('api_key_modal.provider_not_implemented'), 'warning', 5000);
+                    }
+
+                    // プロバイダー固有のキーとして保存
+                    localStorage.setItem(`menu_judge_api_key_${this.selectedProvider}`, trimmedKey);
+                    localStorage.setItem('menu_judge_provider', this.selectedProvider);
+
+                    this.apiKeys[this.selectedProvider] = trimmedKey;
+                    this.apiKey = trimmedKey;
+
                     showToast(t('toast.api_key_saved'), 'success');
                     this.closeModal();
                     this.setupHtmxHeaders();
@@ -395,12 +512,13 @@ function apiKeyManager() {
         },
 
         /**
-         * APIキーをlocalStorageから削除
+         * 現在のプロバイダーのAPIキーをlocalStorageから削除
          */
         deleteApiKey() {
             if (confirm(t('api_key_modal.delete_confirm'))) {
                 try {
-                    localStorage.removeItem('menu_judge_api_key');
+                    localStorage.removeItem(`menu_judge_api_key_${this.selectedProvider}`);
+                    this.apiKeys[this.selectedProvider] = '';
                     this.apiKey = '';
                     this.apiKeyInput = '';
                     showToast(t('toast.api_key_deleted'), 'success');
@@ -434,7 +552,7 @@ function apiKeyManager() {
         },
 
         /**
-         * HTMXリクエストヘッダーにAPIキーを追加
+         * HTMXリクエストヘッダーにAPIキーとプロバイダーを追加
          */
         setupHtmxHeaders() {
             // Remove existing listener if present (prevents duplicates)
@@ -447,6 +565,8 @@ function apiKeyManager() {
                 if (this.apiKey) {
                     event.detail.headers['X-API-Key'] = this.apiKey;
                 }
+                // Add provider header
+                event.detail.headers['X-AI-Provider'] = this.selectedProvider;
                 // Add language header
                 const language = getCurrentLanguage();
                 event.detail.headers['X-Language'] = language;
@@ -468,6 +588,11 @@ function apiKeyManager() {
                 // 401エラー（認証エラー）またはAPIキーエラーの場合
                 if (status === 401 || errorCode === 'NO_API_KEY') {
                     showToast(t('toast.api_key_invalid'), 'error', 5000);
+                    this.showModal = true;
+                }
+                // プロバイダー未実装エラー
+                else if (errorCode === 'PROVIDER_NOT_IMPLEMENTED') {
+                    showToast(t('api_key_modal.provider_not_implemented'), 'warning', 5000);
                     this.showModal = true;
                 }
                 // Other errors

--- a/app/templates/components/api_key_modal.html
+++ b/app/templates/components/api_key_modal.html
@@ -1,4 +1,4 @@
-<!-- API Key Settings Modal -->
+<!-- API Settings Modal -->
 <div x-show="showModal"
      x-cloak
      class="fixed inset-0 z-50 overflow-y-auto"
@@ -36,11 +36,13 @@
                         <div class="rounded-lg bg-white/20 p-2 backdrop-blur-sm">
                             <svg class="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z">
+                                    d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z">
                                 </path>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
                             </svg>
                         </div>
-                        <h3 id="api-key-modal-title" class="text-xl font-bold text-white" x-text="t('api_key_modal.title', 'API Key Settings')"></h3>
+                        <h3 id="api-key-modal-title" class="text-xl font-bold text-white" x-text="t('api_key_modal.title', 'API Settings')"></h3>
                     </div>
                     <button @click="closeModal()" type="button"
                         class="rounded-lg p-1 text-white/80 transition-colors hover:bg-white/10 hover:text-white">
@@ -63,28 +65,60 @@
                                 d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                         </svg>
                         <div class="text-sm text-slate-300 space-y-2">
-                            <p x-text="t('api_key_modal.description', 'Menu analysis requires Claude API.')"></p>
+                            <p x-text="t('api_key_modal.description', 'Menu analysis requires an AI API.')"></p>
                             <p>
                                 <span x-text="t('api_key_modal.get_key_text', 'You can get your API key from')"></span>
-                                <a href="https://console.anthropic.com/settings/keys" target="_blank"
+                                <a :href="getProviderConsoleUrl(selectedProvider)" target="_blank"
                                     rel="noopener noreferrer"
-                                    class="text-blue-400 hover:text-blue-300 underline"
-                                    x-text="t('api_key_modal.get_key_link', 'Anthropic Console')"></a>.
+                                    class="text-blue-400 hover:text-blue-300 underline">
+                                    <span x-text="providers.find(p => p.id === selectedProvider)?.name || 'Provider Console'"></span>
+                                </a>.
                             </p>
                             <p class="text-xs text-slate-400" x-text="t('api_key_modal.storage_notice')"></p>
                         </div>
                     </div>
                 </div>
 
-                <!-- API Key Input Form -->
+                <!-- Provider Selection -->
                 <div class="space-y-4">
                     <div>
+                        <label for="provider-select" class="block text-sm font-medium text-slate-300 mb-2"
+                            x-text="t('api_key_modal.provider_label', 'AI Provider')">
+                        </label>
+                        <div class="relative">
+                            <select id="provider-select"
+                                x-model="selectedProvider"
+                                @change="changeProvider($event.target.value)"
+                                class="w-full appearance-none rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 pr-10 text-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50 transition-all cursor-pointer">
+                                <template x-for="provider in providers" :key="provider.id">
+                                    <option :value="provider.id" x-text="provider.name + (provider.implemented ? '' : ' (Coming Soon)')"></option>
+                                </template>
+                            </select>
+                            <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3">
+                                <svg class="h-5 w-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <!-- Provider not implemented warning -->
+                        <p x-show="!isProviderImplemented(selectedProvider)"
+                           class="mt-2 text-xs text-amber-400 flex items-center gap-1">
+                            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+                            </svg>
+                            <span x-text="t('api_key_modal.provider_not_implemented', 'This provider is not yet implemented.')"></span>
+                        </p>
+                    </div>
+
+                    <!-- API Key Input Form -->
+                    <div>
                         <label for="api-key-input" class="block text-sm font-medium text-slate-300 mb-2"
-                            x-text="t('api_key_modal.input_label', 'Anthropic API Key')">
+                            x-text="t('api_key_modal.input_label', 'API Key')">
                         </label>
                         <div class="relative">
                             <input :type="showApiKey ? 'text' : 'password'" id="api-key-input" x-model="apiKeyInput"
-                                :placeholder="t('api_key_modal.input_placeholder', 'sk-ant-api03-...')"
+                                :placeholder="getProviderPlaceholder(selectedProvider)"
                                 class="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 pr-12 text-white placeholder-slate-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50 transition-all"
                                 @keydown.enter="saveApiKey(apiKeyInput)">
                             <button @click="showApiKey = !showApiKey" type="button"

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -19,19 +19,37 @@
     "loading": "Loading..."
   },
   "api_key_modal": {
-    "title": "API Key Settings",
-    "description": "Menu analysis requires Claude API.",
+    "title": "API Settings",
+    "description": "Menu analysis requires an AI API.",
     "get_key_text": "You can get your API key from",
-    "get_key_link": "Anthropic Console",
+    "get_key_link": "the provider's console",
     "storage_notice": "※ API key is stored in browser's localStorage and never sent to server.",
-    "input_label": "Anthropic API Key",
-    "input_placeholder": "sk-ant-api03-...",
+    "provider_label": "AI Provider",
+    "provider_select_placeholder": "Select AI Provider",
+    "input_label": "API Key",
+    "input_placeholder": "Enter your API key",
     "save_button": "Save",
     "delete_button": "Delete",
     "delete_confirm": "Are you sure you want to delete the API key?",
     "close_modal": "Close",
     "show_api_key": "Show API key",
-    "hide_api_key": "Hide API key"
+    "hide_api_key": "Hide API key",
+    "provider_not_implemented": "This provider is not yet implemented. Please select Claude for now.",
+    "provider_console_links": {
+      "claude": "Anthropic Console",
+      "openai": "OpenAI Platform",
+      "gemini": "Google AI Studio"
+    },
+    "provider_console_urls": {
+      "claude": "https://console.anthropic.com/settings/keys",
+      "openai": "https://platform.openai.com/api-keys",
+      "gemini": "https://aistudio.google.com/app/apikey"
+    },
+    "provider_placeholder": {
+      "claude": "sk-ant-api03-...",
+      "openai": "sk-proj-...",
+      "gemini": "AIza..."
+    }
   },
   "toast": {
     "image_loaded": "Image loaded successfully",
@@ -94,6 +112,7 @@
     "invalid_request": "Invalid Request",
     "server_error": "Server Error",
     "analysis_error": "Analysis Error",
+    "provider_not_implemented": "Provider Not Implemented",
     "file_error": "File Error",
     "network_error": "Network Error",
     "unknown_error": "Unknown Error"

--- a/app/translations/ja.json
+++ b/app/translations/ja.json
@@ -19,19 +19,37 @@
     "loading": "読み込み中..."
   },
   "api_key_modal": {
-    "title": "APIキー設定",
-    "description": "メニュー解析にはClaude APIが必要です。",
+    "title": "API設定",
+    "description": "メニュー解析にはAI APIが必要です。",
     "get_key_text": "APIキーは以下から取得できます",
-    "get_key_link": "Anthropic コンソール",
+    "get_key_link": "プロバイダーのコンソール",
     "storage_notice": "※ APIキーはブラウザのlocalStorageに保存され、サーバーには送信されません。",
-    "input_label": "Anthropic APIキー",
-    "input_placeholder": "sk-ant-api03-...",
+    "provider_label": "AIプロバイダー",
+    "provider_select_placeholder": "AIプロバイダーを選択",
+    "input_label": "APIキー",
+    "input_placeholder": "APIキーを入力",
     "save_button": "保存",
     "delete_button": "削除",
     "delete_confirm": "APIキーを削除してもよろしいですか？",
     "close_modal": "閉じる",
     "show_api_key": "APIキーを表示",
-    "hide_api_key": "APIキーを非表示"
+    "hide_api_key": "APIキーを非表示",
+    "provider_not_implemented": "このプロバイダーはまだ実装されていません。現在はClaudeを選択してください。",
+    "provider_console_links": {
+      "claude": "Anthropic コンソール",
+      "openai": "OpenAI Platform",
+      "gemini": "Google AI Studio"
+    },
+    "provider_console_urls": {
+      "claude": "https://console.anthropic.com/settings/keys",
+      "openai": "https://platform.openai.com/api-keys",
+      "gemini": "https://aistudio.google.com/app/apikey"
+    },
+    "provider_placeholder": {
+      "claude": "sk-ant-api03-...",
+      "openai": "sk-proj-...",
+      "gemini": "AIza..."
+    }
   },
   "toast": {
     "image_loaded": "画像が読み込まれました",
@@ -94,6 +112,7 @@
     "invalid_request": "無効なリクエスト",
     "server_error": "サーバーエラー",
     "analysis_error": "解析エラー",
+    "provider_not_implemented": "プロバイダー未実装",
     "file_error": "ファイルエラー",
     "network_error": "ネットワークエラー",
     "unknown_error": "不明なエラー"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -74,20 +74,47 @@ class TestMenuAnalysisFlow:
 class TestMultipleProviders:
     """複数プロバイダーのテスト"""
 
-    @patch.dict("os.environ", {"AI_PROVIDER": "claude", "ANTHROPIC_API_KEY": "test-key"})
     def test_claude_provider_selection(self, client):
         """Claudeプロバイダーが選択される"""
         from app.services.ai.factory import AIProviderFactory
 
-        provider = AIProviderFactory.create()
+        provider = AIProviderFactory.create(api_key="test-key", provider_name="claude")
         assert provider.name == "claude"
 
-    @patch.dict("os.environ", {"AI_PROVIDER": "invalid"})
     def test_invalid_provider_error(self, client, real_menu_image):
-        """無効なプロバイダーでエラー"""
+        """無効なプロバイダーでエラー（X-AI-Providerヘッダーで指定）"""
         response = client.post(
             "/api/analyze",
             data={"image": (BytesIO(real_menu_image), "menu.jpg")},
+            headers={"X-API-Key": "test-key", "X-AI-Provider": "invalid"},
             content_type="multipart/form-data",
         )
-        assert response.status_code == 500
+        # 未知のプロバイダーは400エラー（PROVIDER_NOT_IMPLEMENTED）
+        assert response.status_code == 400
+        assert response.headers.get("X-Error-Code") == "PROVIDER_NOT_IMPLEMENTED"
+
+    def test_provider_header_is_used(self, client, real_menu_image):
+        """X-AI-Providerヘッダーがバックエンドで使用される"""
+        from app.services.ai.base import AnalysisResult
+
+        with patch("app.services.ai.factory.AIProviderFactory.create") as mock_factory:
+            mock_provider = mock_factory.return_value
+            mock_provider.analyze_menu.return_value = AnalysisResult(
+                dishes=[],
+                raw_response="{}",
+                provider="claude",
+                processing_time=0.5,
+            )
+
+            response = client.post(
+                "/api/analyze",
+                data={"image": (BytesIO(real_menu_image), "menu.jpg")},
+                headers={"X-API-Key": "test-key", "X-AI-Provider": "claude"},
+                content_type="multipart/form-data",
+            )
+
+        assert response.status_code == 200
+        # ファクトリーがclaudeプロバイダーで呼び出されたことを確認
+        mock_factory.assert_called_once()
+        call_kwargs = mock_factory.call_args.kwargs
+        assert call_kwargs["provider_name"] == "claude"


### PR DESCRIPTION
## Summary

- 設定モーダルにAIプロバイダー（Claude/OpenAI/Gemini）選択ドロップダウンを追加
- プロバイダーごとのAPIキー管理機能を実装
- バックエンドでX-AI-Providerヘッダーを読み取り、指定されたプロバイダーを使用
- 未実装プロバイダー選択時の警告とエラーハンドリングを追加

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `app/static/js/app.js` | apiKeyManagerコンポーネントをプロバイダー対応に拡張 |
| `app/templates/components/api_key_modal.html` | プロバイダー選択UIを追加 |
| `app/routes/menu.py` | X-AI-Providerヘッダー読み取り、UnknownProviderErrorハンドリング |
| `app/translations/en.json` | プロバイダー関連の英語翻訳を追加 |
| `app/translations/ja.json` | プロバイダー関連の日本語翻訳を追加 |
| `tests/test_integration.py` | プロバイダー選択のテストを追加・修正 |

## スクリーンショット

プロバイダー選択ドロップダウンが設定モーダルに追加されます。

## Test plan

- [ ] 設定モーダルでClaude/OpenAI/Geminiを選択できることを確認
- [ ] 選択したプロバイダーがlocalStorageに保存されることを確認
- [ ] Claudeを選択してメニュー解析が正常に動作することを確認
- [ ] OpenAI/Gemini選択時に「未実装」警告が表示されることを確認
- [ ] 未実装プロバイダーでAPIリクエストした場合、適切なエラーが返ることを確認
- [ ] 後方互換性: 既存のAPIキーが正しく移行されることを確認

## Related Issues

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)