### PR TITLE
feat: カテゴリフィルタ機能を追加 (#48)

### DIFF
--- a/app/templates/partials/dish_list.html
+++ b/app/templates/partials/dish_list.html
@@ -12,13 +12,30 @@ Arguments:
 {% from 'components/dish_card.html' import dish_card %}
 {% from 'components/image_with_boxes.html' import image_with_boxes %}
 
-<div id="dish-list" class="space-y-4" x-data="{ showImageModal: false }">
+{# dishes に登場するカテゴリと件数を集計（表示順は登場順） #}
+{% set category_counts = {} %}
+{% for d in dishes %}
+    {% set _ = category_counts.update({d.category.value: category_counts.get(d.category.value, 0) + 1}) %}
+{% endfor %}
+{# all を先頭に据えた件数マップを JSON へ #}
+{% set all_counts = {'all': dishes | length} %}
+{% for k, v in category_counts.items() %}
+    {% set _ = all_counts.update({k: v}) %}
+{% endfor %}
+
+<div id="dish-list" class="space-y-4"
+     x-data="{
+        showImageModal: false,
+        selectedCategory: 'all',
+        counts: {{ all_counts | tojson }},
+        get filteredCount() { return this.counts[this.selectedCategory] ?? 0; }
+     }">
     <!-- Results Summary -->
     <div class="flex flex-wrap justify-between items-center gap-2 mb-4">
         <h2 class="text-xl font-bold">
             {{ t('results.title', 'Analysis Results') }}
             <span class="text-sm text-slate-400">
-                ({{ dishes | length }} {{ t('results.dish_count', 'dishes') }})
+                (<span data-testid="filtered-count" x-text="filteredCount">{{ dishes | length }}</span> {{ t('results.dish_count', 'dishes') }})
             </span>
         </h2>
         <div class="flex items-center gap-4">
@@ -43,11 +60,58 @@ Arguments:
         </div>
     </div>
 
+    <!-- Category Filter Bar (2カテゴリ以上あるときのみ表示) -->
+    {% if dishes and category_counts | length > 1 %}
+    <div
+        data-testid="category-filter"
+        role="tablist"
+        aria-label="{{ t('results.filter_aria_label', 'Filter dishes by category') }}"
+        class="flex flex-wrap gap-2 mb-4"
+    >
+        <button
+            type="button"
+            role="tab"
+            data-category="all"
+            data-count="{{ dishes | length }}"
+            @click="selectedCategory = 'all'"
+            :aria-selected="selectedCategory === 'all'"
+            :class="selectedCategory === 'all'
+                    ? 'bg-primary text-white border-primary'
+                    : 'bg-slate-800 text-slate-300 border-slate-700 hover:border-primary'"
+            class="px-3 py-1.5 rounded-lg text-sm border transition-colors"
+        >
+            {{ t('results.filter_all', 'All') }} ({{ dishes | length }})
+        </button>
+        {% for cat, cnt in category_counts.items() %}
+        <button
+            type="button"
+            role="tab"
+            data-category="{{ cat }}"
+            data-count="{{ cnt }}"
+            @click="selectedCategory = '{{ cat }}'"
+            :aria-selected="selectedCategory === '{{ cat }}'"
+            :class="selectedCategory === '{{ cat }}'
+                    ? 'bg-primary text-white border-primary'
+                    : 'bg-slate-800 text-slate-300 border-slate-700 hover:border-primary'"
+            class="px-3 py-1.5 rounded-lg text-sm border transition-colors"
+        >
+            {{ t('results.filter_category_' ~ cat, cat) }} ({{ cnt }})
+        </button>
+        {% endfor %}
+    </div>
+    {% endif %}
+
     <!-- Dish Card Grid -->
     {% if dishes %}
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {% for dish in dishes %}
-            {{ dish_card(dish, dish.number or loop.index) }}
+            <div
+                class="dish-card-wrapper"
+                data-category="{{ dish.category.value }}"
+                x-show="selectedCategory === 'all' || selectedCategory === '{{ dish.category.value }}'"
+            >
+                {{ dish_card(dish, dish.number or loop.index) }}
+            </div>
         {% endfor %}
     </div>
 

--- a/app/translations/en.json
+++ b/app/translations/en.json
@@ -102,7 +102,14 @@
     "analyzed_with": "Analyzed with",
     "no_dishes_detected": "No dishes detected",
     "try_different_image": "Please try a different image",
-    "hover_hint": "Hover over numbers to highlight corresponding dishes"
+    "hover_hint": "Hover over numbers to highlight corresponding dishes",
+    "filter_aria_label": "Filter dishes by category",
+    "filter_all": "All",
+    "filter_category_appetizer": "Appetizer",
+    "filter_category_main": "Main",
+    "filter_category_dessert": "Dessert",
+    "filter_category_beverage": "Beverage",
+    "filter_category_other": "Other"
   },
   "error": {
     "title": "An Error Occurred",

--- a/app/translations/ja.json
+++ b/app/translations/ja.json
@@ -102,7 +102,14 @@
     "analyzed_with": "解析エンジン:",
     "no_dishes_detected": "料理が検出されませんでした",
     "try_different_image": "別の画像をお試しください",
-    "hover_hint": "番号にホバーすると対応する料理がハイライトされます"
+    "hover_hint": "番号にホバーすると対応する料理がハイライトされます",
+    "filter_aria_label": "カテゴリで料理を絞り込み",
+    "filter_all": "すべて",
+    "filter_category_appetizer": "前菜",
+    "filter_category_main": "メイン",
+    "filter_category_dessert": "デザート",
+    "filter_category_beverage": "ドリンク",
+    "filter_category_other": "その他"
   },
   "error": {
     "title": "エラーが発生しました",

--- a/tests/test_dish_filter.py
+++ b/tests/test_dish_filter.py
@@ -1,0 +1,194 @@
+"""カテゴリフィルタ機能のテスト（Issue #48）
+
+Alpine.js によるクライアント側フィルタリングの構造を検証する。
+ブラウザ上の実動作（クリックで表示が切り替わる等）は別途 E2E で確認する。
+"""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask, render_template
+
+from app import create_app
+from app.models.dish import Category, Dish
+
+
+@pytest.fixture
+def app() -> Flask:
+    """テスト用の Flask アプリケーション"""
+    return create_app({"TESTING": True, "SECRET_KEY": "test-secret-key"})
+
+
+@pytest.fixture
+def multi_category_dishes() -> list[Dish]:
+    """複数カテゴリをまたぐ料理リスト"""
+    return [
+        Dish(
+            original_name="Spring Roll",
+            translated_name="春巻き",
+            description="前菜",
+            spiciness=1,
+            sweetness=1,
+            category=Category.APPETIZER,
+            number=1,
+        ),
+        Dish(
+            original_name="Pad Thai",
+            translated_name="パッタイ",
+            description="メイン",
+            spiciness=2,
+            sweetness=3,
+            category=Category.MAIN,
+            number=2,
+        ),
+        Dish(
+            original_name="Green Curry",
+            translated_name="グリーンカレー",
+            description="メイン",
+            spiciness=4,
+            sweetness=2,
+            category=Category.MAIN,
+            number=3,
+        ),
+        Dish(
+            original_name="Mango Sticky Rice",
+            translated_name="マンゴーもち米",
+            description="デザート",
+            spiciness=1,
+            sweetness=5,
+            category=Category.DESSERT,
+            number=4,
+        ),
+    ]
+
+
+def _render(app: Flask, dishes: list[Dish]) -> str:
+    with app.test_request_context("/?lang=ja"):
+        return render_template(
+            "partials/dish_list.html",
+            dishes=dishes,
+            provider="claude",
+            processing_time=0.1,
+        )
+
+
+def test_filter_container_is_rendered(app: Flask, multi_category_dishes: list[Dish]) -> None:
+    """カテゴリフィルタのコンテナがレンダリングされる"""
+    html = _render(app, multi_category_dishes)
+    assert 'data-testid="category-filter"' in html
+
+
+def test_filter_uses_alpine_state(app: Flask, multi_category_dishes: list[Dish]) -> None:
+    """Alpine.js の selectedCategory 状態が 'all' 初期化で存在する"""
+    html = _render(app, multi_category_dishes)
+    # 親スコープの x-data に selectedCategory: 'all' を持つ
+    assert "selectedCategory" in html
+    assert "'all'" in html
+
+
+def test_filter_renders_all_button(app: Flask, multi_category_dishes: list[Dish]) -> None:
+    """『すべて表示』ボタンがレンダリングされる"""
+    html = _render(app, multi_category_dishes)
+    # data 属性で識別可能
+    assert 'data-category="all"' in html
+    # ja 翻訳の文言
+    assert "すべて" in html
+
+
+def test_filter_renders_button_per_present_category(
+    app: Flask, multi_category_dishes: list[Dish]
+) -> None:
+    """解析結果に存在するカテゴリごとにフィルタボタンが出る"""
+    html = _render(app, multi_category_dishes)
+    # dishes に含まれるカテゴリ: appetizer, main, dessert
+    assert 'data-category="appetizer"' in html
+    assert 'data-category="main"' in html
+    assert 'data-category="dessert"' in html
+    # 含まれないものは描画しない（ノイズ抑制）
+    assert 'data-category="beverage"' not in html
+
+
+def test_filter_buttons_set_selected_category_on_click(
+    app: Flask, multi_category_dishes: list[Dish]
+) -> None:
+    """各ボタンの @click で selectedCategory を更新する"""
+    html = _render(app, multi_category_dishes)
+    assert "selectedCategory = 'all'" in html
+    assert "selectedCategory = 'main'" in html
+
+
+def test_filter_button_highlights_active_state(
+    app: Flask, multi_category_dishes: list[Dish]
+) -> None:
+    """選択中のボタンは :class バインドでアクティブ表示される"""
+    html = _render(app, multi_category_dishes)
+    # アクティブ判定に selectedCategory === '<cat>' を使う
+    assert "selectedCategory === 'all'" in html
+    assert "selectedCategory === 'main'" in html
+
+
+def test_filter_button_shows_category_count(
+    app: Flask, multi_category_dishes: list[Dish]
+) -> None:
+    """各ボタンに件数が表示される（main は 2 件、dessert は 1 件）"""
+    html = _render(app, multi_category_dishes)
+    # data-count 属性として件数を保持
+    assert 'data-count="2"' in html  # main
+    assert 'data-count="1"' in html  # appetizer/dessert
+    # 全件数（4）も all ボタン側で出す
+    assert 'data-count="4"' in html
+
+
+def test_dish_cards_have_category_data_attribute(
+    app: Flask, multi_category_dishes: list[Dish]
+) -> None:
+    """各 dish-card が自身のカテゴリを data 属性で持つ（Alpine フィルタの鍵）"""
+    html = _render(app, multi_category_dishes)
+    assert 'data-category="main"' in html
+    assert 'data-category="appetizer"' in html
+    assert 'data-category="dessert"' in html
+
+
+def test_dish_cards_use_x_show_for_filtering(
+    app: Flask, multi_category_dishes: list[Dish]
+) -> None:
+    """料理カードは x-show で selectedCategory との一致を見て表示を切替える"""
+    html = _render(app, multi_category_dishes)
+    # x-show 内で selectedCategory と card のカテゴリを比較する式が入る
+    assert "selectedCategory === 'all'" in html
+    # 各カテゴリの条件が x-show 上に並ぶ
+    assert "x-show=\"selectedCategory === 'all' || selectedCategory === 'main'\"" in html
+
+
+def test_filtered_count_uses_alpine_x_text(
+    app: Flask, multi_category_dishes: list[Dish]
+) -> None:
+    """フィルタ後の件数は Alpine の x-text で動的に出す"""
+    html = _render(app, multi_category_dishes)
+    assert 'data-testid="filtered-count"' in html
+    # x-text で件数を差し替え（実装で使う変数名は filteredCount を推奨）
+    assert "filteredCount" in html
+
+
+def test_filter_is_hidden_when_no_dishes(app: Flask) -> None:
+    """料理が 0 件のときはフィルタを出さない"""
+    html = _render(app, [])
+    assert 'data-testid="category-filter"' not in html
+
+
+def test_filter_is_hidden_when_only_one_category(app: Flask) -> None:
+    """単一カテゴリしかない場合、フィルタUIは不要なので描画しない"""
+    dishes = [
+        Dish(
+            original_name=f"Dish{i}",
+            translated_name=f"料理{i}",
+            description="desc",
+            spiciness=1,
+            sweetness=1,
+            category=Category.MAIN,
+            number=i,
+        )
+        for i in range(1, 4)
+    ]
+    html = _render(app, dishes)
+    assert 'data-testid="category-filter"' not in html


### PR DESCRIPTION
## Summary
- 解析結果画面にカテゴリタブ（appetizer / main / dessert / beverage / other）を追加し、クライアント側（Alpine.js）で料理カードを絞り込めるようにした
- 「すべて」オプション＋各カテゴリの件数を表示し、フィルタ後の件数も動的に更新
- 2 カテゴリ以上ある場合のみフィルタバーを表示（単一カテゴリ時はノイズ抑制）

## 実装の要点
- `app/templates/partials/dish_list.html`
  - Jinja2 で dishes からカテゴリ別件数 (`category_counts`) と all 込み件数 (`all_counts`) を集計し、Alpine の `x-data` に JSON 注入
  - `get filteredCount()` で `selectedCategory` に応じた件数を返すゲッター
  - dish-card を `x-show="selectedCategory === 'all' || selectedCategory === '<cat>'"` の wrapper で囲む
- `app/translations/{ja,en}.json`: `results.filter_all` / `filter_category_*` / `filter_aria_label` を追加
- `tests/test_dish_filter.py`: 新規 12 ケース（UI 構造 / Alpine 状態 / 件数 / 非表示条件）

## 受け入れ条件
- [x] 解析結果画面でカテゴリフィルタが表示される
- [x] フィルタ選択時に該当カテゴリの料理のみ表示される
- [x] フィルタ解除（「すべて」）で全料理が表示される
- [x] フィルタ後の件数が表示される

## Test plan
- [x] `pytest tests/test_dish_filter.py -v` → 12/12 pass
- [x] `pytest --cov=app` → 248 passed, coverage 100% (450/450 stmts)
- [ ] ブラウザでの手動確認（/ にアクセス → メニュー解析 → タブ切替で表示更新）
- [ ] 単一カテゴリのみ返ってきたときフィルタバーが出ないこと
- [ ] ja/en 切替でラベルが切り替わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)