### PR TITLE
feat: OpenAIプロバイダー追加 + UIライトモード化 (#53, #57)

### DIFF
--- a/app/services/ai/claude_provider.py
+++ b/app/services/ai/claude_provider.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import base64
-import json
 import logging
 import time
-from dataclasses import replace
 from typing import Literal, cast
 
 import anthropic
@@ -17,9 +15,9 @@ from app.services.ai.base import (
     AnalysisResult,
     APICallError,
     APIKeyMissingError,
-    InvalidMenuImageError,
 )
 from app.services.ai.prompt_builder import PromptBuilder
+from app.services.ai.response_parser import parse_dishes
 
 logger = logging.getLogger(__name__)
 
@@ -186,82 +184,5 @@ class ClaudeProvider(AIProvider):
         return base_prompt + extra_instructions
 
     def _parse_response(self, response: str) -> list[Dish]:
-        """
-        Parse Claude response to list of Dish objects.
-
-        Args:
-            response: Claude API response text
-
-        Returns:
-            List of Dish objects
-
-        Raises:
-            APICallError: Failed to parse response
-            InvalidMenuImageError: No dishes could be detected
-        """
-        cleaned = self._strip_markdown_fences(response)
-
-        try:
-            data = json.loads(cleaned)
-        except json.JSONDecodeError as e:
-            raise APICallError(f"Failed to parse JSON response: {e}") from e
-
-        if not isinstance(data, dict) or "dishes" not in data:
-            raise APICallError("Response must contain 'dishes' key")
-
-        dishes: list[Dish] = []
-        for dish_data in data["dishes"]:
-            try:
-                dishes.append(Dish.from_dict(dish_data))
-            except (ValueError, KeyError, TypeError) as e:
-                logger.warning("Failed to parse dish: %s", e, exc_info=True)
-                continue
-
-        if not dishes:
-            raise InvalidMenuImageError(
-                "Could not detect menu from image. "
-                "Please verify that the image is a photo of a menu."
-            )
-
-        dishes = self._normalize_dish_numbers(dishes)
-        return dishes
-
-    @staticmethod
-    def _normalize_dish_numbers(dishes: list[Dish]) -> list[Dish]:
-        """料理番号の欠損・重複・非連続を検出し、必要なら連番を振り直す。
-
-        AIが番号を省略・重複・スキップした場合や、無効dishのスキップで
-        番号が飛んだ場合（例: [1, 3, 4]）、インデックス順で連番を再割当て
-        する。完全な連番（順不同可）の場合はnumber順にソートしてから返す。
-
-        Args:
-            dishes: AIから返された料理リスト
-
-        Returns:
-            numberが正規化された料理リスト（イミュータブル: 新しいリストを返す）
-        """
-        numbers = [d.number for d in dishes]
-        expected = list(range(1, len(dishes) + 1))
-        has_missing = any(n is None for n in numbers)
-        is_sequential = not has_missing and sorted(numbers) == expected  # type: ignore[type-var]
-
-        if not is_sequential:
-            logger.warning(
-                "Dish numbers invalid (numbers=%s); reassigning sequential numbers",
-                numbers,
-            )
-            return [replace(d, number=i + 1) for i, d in enumerate(dishes)]
-
-        return sorted(dishes, key=lambda d: d.number)  # type: ignore[arg-type,return-value]
-
-    @staticmethod
-    def _strip_markdown_fences(response: str) -> str:
-        """Strip markdown code fences from Claude response text."""
-        cleaned = response.strip()
-        if cleaned.startswith("```json"):
-            cleaned = cleaned[7:]
-        if cleaned.startswith("```"):
-            cleaned = cleaned[3:]
-        if cleaned.endswith("```"):
-            cleaned = cleaned[:-3]
-        return cleaned.strip()
+        """Parse Claude response into a list of Dish objects."""
+        return parse_dishes(response)

--- a/app/services/ai/factory.py
+++ b/app/services/ai/factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .base import AIProvider, AIProviderError, APIKeyMissingError
 from .claude_provider import ClaudeProvider
+from .openai_provider import OpenAIProvider
 
 
 class UnknownProviderError(AIProviderError):
@@ -17,6 +18,7 @@ class AIProviderFactory:
 
     _providers: dict[str, type[AIProvider]] = {
         "claude": ClaudeProvider,
+        "openai": OpenAIProvider,
     }
 
     @classmethod

--- a/app/services/ai/openai_provider.py
+++ b/app/services/ai/openai_provider.py
@@ -1,0 +1,187 @@
+"""OpenAI GPT-4V provider for menu analysis."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+from dataclasses import replace
+
+import openai
+from openai import OpenAI
+
+from app.models.dish import Dish
+from app.services.ai.base import (
+    AIProvider,
+    AnalysisResult,
+    APICallError,
+    APIKeyMissingError,
+    InvalidMenuImageError,
+)
+from app.services.ai.prompt_builder import PromptBuilder
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(AIProvider):
+    """OpenAI GPT-4V を使用した画像解析プロバイダー"""
+
+    MODEL = "gpt-4o"
+    MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10MB
+    MAX_TOKENS = 4096
+
+    def __init__(self, api_key: str, language: str = "en") -> None:
+        """
+        Initialize OpenAI provider.
+
+        Args:
+            api_key: OpenAI API key
+            language: Language code for responses ('en' or 'ja')
+        """
+        super().__init__(api_key, language)
+        if not self.api_key:
+            raise APIKeyMissingError("API key is required")
+        self.client = OpenAI(api_key=self.api_key)
+        self.prompt_builder = PromptBuilder(language)
+
+    @property
+    def name(self) -> str:
+        """Return provider name."""
+        return "openai"
+
+    def analyze_menu(self, image_data: bytes, mime_type: str) -> AnalysisResult:
+        """
+        Analyze menu image via GPT-4V.
+
+        Args:
+            image_data: Image binary data
+            mime_type: Image MIME type (validated at route layer)
+
+        Returns:
+            AnalysisResult: Parsed analysis result
+
+        Raises:
+            APICallError: Image too large, API failure, or parsing error
+            InvalidMenuImageError: No dishes detected
+        """
+        if len(image_data) > self.MAX_IMAGE_SIZE:
+            raise APICallError(
+                f"Image size {len(image_data)} bytes exceeds maximum "
+                f"{self.MAX_IMAGE_SIZE} bytes"
+            )
+
+        start_time = time.time()
+
+        try:
+            image_base64 = base64.standard_b64encode(image_data).decode("utf-8")
+            data_url = f"data:{mime_type};base64,{image_base64}"
+            prompt = self._build_prompt()
+
+            response = self.client.chat.completions.create(
+                model=self.MODEL,
+                max_tokens=self.MAX_TOKENS,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": prompt},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": data_url},
+                            },
+                        ],
+                    }
+                ],
+            )
+
+            raw_response = response.choices[0].message.content or ""
+            dishes = self._parse_response(raw_response)
+            processing_time = time.time() - start_time
+
+            return AnalysisResult(
+                dishes=dishes,
+                raw_response=raw_response,
+                provider=self.name,
+                processing_time=processing_time,
+            )
+
+        except InvalidMenuImageError:
+            raise
+        except APICallError:
+            raise
+        except openai.APIError as e:
+            raise APICallError(f"OpenAI API call failed: {e}") from e
+        except Exception as e:
+            raise APICallError(f"Unexpected error during analysis: {e}") from e
+
+    def _build_prompt(self) -> str:
+        """Build menu analysis prompt using the shared multilingual builder."""
+        base_prompt = self.prompt_builder.build_menu_analysis_prompt()
+
+        number_instruction = """
+- number: Dish order number in the menu image (integer, starting from 1)
+  Assign numbers in reading order: top-to-bottom, then left-to-right for multi-column menus.
+  Every dish MUST have a unique sequential number."""
+
+        if "```json" in base_prompt:
+            parts = base_prompt.split("```json")
+            return parts[0] + number_instruction + "\n\n```json" + parts[1]
+        return base_prompt + number_instruction
+
+    def _parse_response(self, response: str) -> list[Dish]:
+        """Parse GPT-4V JSON response into Dish list."""
+        cleaned = self._strip_markdown_fences(response)
+
+        try:
+            data = json.loads(cleaned)
+        except json.JSONDecodeError as e:
+            raise APICallError(f"Failed to parse JSON response: {e}") from e
+
+        if not isinstance(data, dict) or "dishes" not in data:
+            raise APICallError("Response must contain 'dishes' key")
+
+        dishes: list[Dish] = []
+        for dish_data in data["dishes"]:
+            try:
+                dishes.append(Dish.from_dict(dish_data))
+            except (ValueError, KeyError, TypeError) as e:
+                logger.warning("Failed to parse dish: %s", e, exc_info=True)
+                continue
+
+        if not dishes:
+            raise InvalidMenuImageError(
+                "Could not detect menu from image. "
+                "Please verify that the image is a photo of a menu."
+            )
+
+        return self._normalize_dish_numbers(dishes)
+
+    @staticmethod
+    def _normalize_dish_numbers(dishes: list[Dish]) -> list[Dish]:
+        """Reassign sequential numbers if missing/duplicate/non-sequential."""
+        numbers = [d.number for d in dishes]
+        expected = list(range(1, len(dishes) + 1))
+        has_missing = any(n is None for n in numbers)
+        is_sequential = not has_missing and sorted(numbers) == expected  # type: ignore[type-var]
+
+        if not is_sequential:
+            logger.warning(
+                "Dish numbers invalid (numbers=%s); reassigning sequential numbers",
+                numbers,
+            )
+            return [replace(d, number=i + 1) for i, d in enumerate(dishes)]
+
+        return sorted(dishes, key=lambda d: d.number)  # type: ignore[arg-type,return-value]
+
+    @staticmethod
+    def _strip_markdown_fences(response: str) -> str:
+        """Strip ```json / ``` fences from a response body."""
+        cleaned = response.strip()
+        if cleaned.startswith("```json"):
+            cleaned = cleaned[7:]
+        if cleaned.startswith("```"):
+            cleaned = cleaned[3:]
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3]
+        return cleaned.strip()

--- a/app/services/ai/openai_provider.py
+++ b/app/services/ai/openai_provider.py
@@ -3,31 +3,33 @@
 from __future__ import annotations
 
 import base64
-import json
 import logging
 import time
-from dataclasses import replace
 
 import openai
 from openai import OpenAI
 
-from app.models.dish import Dish
 from app.services.ai.base import (
     AIProvider,
     AnalysisResult,
     APICallError,
     APIKeyMissingError,
-    InvalidMenuImageError,
 )
 from app.services.ai.prompt_builder import PromptBuilder
+from app.services.ai.response_parser import parse_dishes
 
 logger = logging.getLogger(__name__)
 
+_NUMBER_FIELD_INSTRUCTION = """
+- number: Dish order number in the menu image (integer, starting from 1)
+  Assign numbers in reading order: top-to-bottom, then left-to-right for multi-column menus.
+  Every dish MUST have a unique sequential number."""
+
 
 class OpenAIProvider(AIProvider):
-    """OpenAIのビジョン対応モデルを使用した画像解析プロバイダー。
+    """OpenAI ビジョン対応モデルを使った画像解析プロバイダー。
 
-    デフォルトでは GPT-5.4 を使用（2026年3月リリースのフラッグシップ）。
+    デフォルトは GPT-5.4（2026年3月リリースのフラッグシップ）。
     画像理解・チャート推論・レイアウト把握が強化され、10Mピクセル超の画像も圧縮不要。
     """
 
@@ -36,13 +38,6 @@ class OpenAIProvider(AIProvider):
     MAX_TOKENS = 4096
 
     def __init__(self, api_key: str, language: str = "en") -> None:
-        """
-        Initialize OpenAI provider.
-
-        Args:
-            api_key: OpenAI API key
-            language: Language code for responses ('en' or 'ja')
-        """
         super().__init__(api_key, language)
         if not self.api_key:
             raise APIKeyMissingError("API key is required")
@@ -51,37 +46,32 @@ class OpenAIProvider(AIProvider):
 
     @property
     def name(self) -> str:
-        """Return provider name."""
         return "openai"
 
     def analyze_menu(self, image_data: bytes, mime_type: str) -> AnalysisResult:
-        """
-        Analyze menu image via GPT-4V.
-
-        Args:
-            image_data: Image binary data
-            mime_type: Image MIME type (validated at route layer)
-
-        Returns:
-            AnalysisResult: Parsed analysis result
-
-        Raises:
-            APICallError: Image too large, API failure, or parsing error
-            InvalidMenuImageError: No dishes detected
-        """
         if len(image_data) > self.MAX_IMAGE_SIZE:
             raise APICallError(
                 f"Image size {len(image_data)} bytes exceeds maximum "
                 f"{self.MAX_IMAGE_SIZE} bytes"
             )
 
-        start_time = time.time()
+        started = time.time()
+        raw_response = self._call_api(image_data, mime_type)
+        dishes = parse_dishes(raw_response)
+
+        return AnalysisResult(
+            dishes=dishes,
+            raw_response=raw_response,
+            provider=self.name,
+            processing_time=time.time() - started,
+        )
+
+    def _call_api(self, image_data: bytes, mime_type: str) -> str:
+        """Chat Completions エンドポイントを叩き、レスポンス本文だけ返す。"""
+        image_base64 = base64.standard_b64encode(image_data).decode("utf-8")
+        data_url = f"data:{mime_type};base64,{image_base64}"
 
         try:
-            image_base64 = base64.standard_b64encode(image_data).decode("utf-8")
-            data_url = f"data:{mime_type};base64,{image_base64}"
-            prompt = self._build_prompt()
-
             response = self.client.chat.completions.create(
                 model=self.MODEL,
                 max_tokens=self.MAX_TOKENS,
@@ -89,103 +79,23 @@ class OpenAIProvider(AIProvider):
                     {
                         "role": "user",
                         "content": [
-                            {"type": "text", "text": prompt},
-                            {
-                                "type": "image_url",
-                                "image_url": {"url": data_url},
-                            },
+                            {"type": "text", "text": self._build_prompt()},
+                            {"type": "image_url", "image_url": {"url": data_url}},
                         ],
                     }
                 ],
             )
-
-            raw_response = response.choices[0].message.content or ""
-            dishes = self._parse_response(raw_response)
-            processing_time = time.time() - start_time
-
-            return AnalysisResult(
-                dishes=dishes,
-                raw_response=raw_response,
-                provider=self.name,
-                processing_time=processing_time,
-            )
-
-        except InvalidMenuImageError:
-            raise
-        except APICallError:
-            raise
         except openai.APIError as e:
             raise APICallError(f"OpenAI API call failed: {e}") from e
         except Exception as e:
             raise APICallError(f"Unexpected error during analysis: {e}") from e
 
+        return response.choices[0].message.content or ""
+
     def _build_prompt(self) -> str:
-        """Build menu analysis prompt using the shared multilingual builder."""
-        base_prompt = self.prompt_builder.build_menu_analysis_prompt()
-
-        number_instruction = """
-- number: Dish order number in the menu image (integer, starting from 1)
-  Assign numbers in reading order: top-to-bottom, then left-to-right for multi-column menus.
-  Every dish MUST have a unique sequential number."""
-
-        if "```json" in base_prompt:
-            parts = base_prompt.split("```json")
-            return parts[0] + number_instruction + "\n\n```json" + parts[1]
-        return base_prompt + number_instruction
-
-    def _parse_response(self, response: str) -> list[Dish]:
-        """Parse GPT-4V JSON response into Dish list."""
-        cleaned = self._strip_markdown_fences(response)
-
-        try:
-            data = json.loads(cleaned)
-        except json.JSONDecodeError as e:
-            raise APICallError(f"Failed to parse JSON response: {e}") from e
-
-        if not isinstance(data, dict) or "dishes" not in data:
-            raise APICallError("Response must contain 'dishes' key")
-
-        dishes: list[Dish] = []
-        for dish_data in data["dishes"]:
-            try:
-                dishes.append(Dish.from_dict(dish_data))
-            except (ValueError, KeyError, TypeError) as e:
-                logger.warning("Failed to parse dish: %s", e, exc_info=True)
-                continue
-
-        if not dishes:
-            raise InvalidMenuImageError(
-                "Could not detect menu from image. "
-                "Please verify that the image is a photo of a menu."
-            )
-
-        return self._normalize_dish_numbers(dishes)
-
-    @staticmethod
-    def _normalize_dish_numbers(dishes: list[Dish]) -> list[Dish]:
-        """Reassign sequential numbers if missing/duplicate/non-sequential."""
-        numbers = [d.number for d in dishes]
-        expected = list(range(1, len(dishes) + 1))
-        has_missing = any(n is None for n in numbers)
-        is_sequential = not has_missing and sorted(numbers) == expected  # type: ignore[type-var]
-
-        if not is_sequential:
-            logger.warning(
-                "Dish numbers invalid (numbers=%s); reassigning sequential numbers",
-                numbers,
-            )
-            return [replace(d, number=i + 1) for i, d in enumerate(dishes)]
-
-        return sorted(dishes, key=lambda d: d.number)  # type: ignore[arg-type,return-value]
-
-    @staticmethod
-    def _strip_markdown_fences(response: str) -> str:
-        """Strip ```json / ``` fences from a response body."""
-        cleaned = response.strip()
-        if cleaned.startswith("```json"):
-            cleaned = cleaned[7:]
-        if cleaned.startswith("```"):
-            cleaned = cleaned[3:]
-        if cleaned.endswith("```"):
-            cleaned = cleaned[:-3]
-        return cleaned.strip()
+        """多言語プロンプトに number フィールドの指示を差し込む。"""
+        base = self.prompt_builder.build_menu_analysis_prompt()
+        if "```json" in base:
+            head, tail = base.split("```json", 1)
+            return f"{head}{_NUMBER_FIELD_INSTRUCTION}\n\n```json{tail}"
+        return base + _NUMBER_FIELD_INSTRUCTION

--- a/app/services/ai/openai_provider.py
+++ b/app/services/ai/openai_provider.py
@@ -1,4 +1,4 @@
-"""OpenAI GPT-4V provider for menu analysis."""
+"""OpenAI vision provider for menu analysis."""
 
 from __future__ import annotations
 
@@ -25,9 +25,13 @@ logger = logging.getLogger(__name__)
 
 
 class OpenAIProvider(AIProvider):
-    """OpenAI GPT-4V を使用した画像解析プロバイダー"""
+    """OpenAIのビジョン対応モデルを使用した画像解析プロバイダー。
 
-    MODEL = "gpt-4o"
+    デフォルトでは GPT-5.4 を使用（2026年3月リリースのフラッグシップ）。
+    画像理解・チャート推論・レイアウト把握が強化され、10Mピクセル超の画像も圧縮不要。
+    """
+
+    MODEL = "gpt-5.4"
     MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10MB
     MAX_TOKENS = 4096
 

--- a/app/services/ai/response_parser.py
+++ b/app/services/ai/response_parser.py
@@ -1,0 +1,90 @@
+"""AIビジョンプロバイダー共通のレスポンス解析ヘルパー。
+
+Claude / OpenAI など複数プロバイダーが同じ JSON 契約（``{"dishes": [...]}``）で
+料理情報を返すため、パース・番号正規化・フェンス除去は共通化している。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import replace
+
+from app.models.dish import Dish
+from app.services.ai.base import APICallError, InvalidMenuImageError
+
+logger = logging.getLogger(__name__)
+
+
+def parse_dishes(response: str) -> list[Dish]:
+    """AI レスポンス本文から Dish のリストを生成する。
+
+    Markdown コードフェンス除去 → JSON パース → Dish 変換（不正な dish は
+    スキップ）→ 番号正規化までを 1 関数で担う。
+
+    Args:
+        response: AI からの生レスポンス本文
+
+    Returns:
+        有効な Dish のリスト（番号は 1-indexed の連番に正規化済み）
+
+    Raises:
+        APICallError: JSON として解釈不能、または ``dishes`` キー欠落
+        InvalidMenuImageError: 有効な dish が 1 件も得られない
+    """
+    cleaned = _strip_markdown_fences(response)
+
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise APICallError(f"Failed to parse JSON response: {e}") from e
+
+    if not isinstance(data, dict) or "dishes" not in data:
+        raise APICallError("Response must contain 'dishes' key")
+
+    dishes: list[Dish] = []
+    for item in data["dishes"]:
+        try:
+            dishes.append(Dish.from_dict(item))
+        except (ValueError, KeyError, TypeError) as e:
+            logger.warning("Failed to parse dish: %s", e, exc_info=True)
+
+    if not dishes:
+        raise InvalidMenuImageError(
+            "Could not detect menu from image. "
+            "Please verify that the image is a photo of a menu."
+        )
+
+    return _normalize_dish_numbers(dishes)
+
+
+def _strip_markdown_fences(response: str) -> str:
+    """先頭/末尾の markdown コードフェンスを除去した本文を返す。"""
+    cleaned = response.strip()
+    if cleaned.startswith("```json"):
+        cleaned = cleaned[7:]
+    elif cleaned.startswith("```"):
+        cleaned = cleaned[3:]
+    if cleaned.endswith("```"):
+        cleaned = cleaned[:-3]
+    return cleaned.strip()
+
+
+def _normalize_dish_numbers(dishes: list[Dish]) -> list[Dish]:
+    """番号の欠損・重複・非連続を検出し、必要ならインデックス順で振り直す。
+
+    完全な連番（順不同可）の場合は number 順にソートして返す。
+    """
+    numbers = [d.number for d in dishes]
+    expected = list(range(1, len(dishes) + 1))
+    has_missing = any(n is None for n in numbers)
+    is_sequential = not has_missing and sorted(numbers) == expected  # type: ignore[type-var]
+
+    if not is_sequential:
+        logger.warning(
+            "Dish numbers invalid (numbers=%s); reassigning sequential numbers",
+            numbers,
+        )
+        return [replace(d, number=i + 1) for i, d in enumerate(dishes)]
+
+    return sorted(dishes, key=lambda d: d.number)  # type: ignore[arg-type,return-value]

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -656,16 +656,18 @@ video {
   position: sticky;
 }
 
-.-inset-1 {
-  inset: -0.25rem;
-}
-
-.-inset-full {
-  inset: -100%;
-}
-
 .inset-0 {
   inset: 0px;
+}
+
+.inset-x-0 {
+  left: 0px;
+  right: 0px;
+}
+
+.inset-y-0 {
+  top: 0px;
+  bottom: 0px;
 }
 
 .-left-3 {
@@ -684,16 +686,16 @@ video {
   top: -0.75rem;
 }
 
+.bottom-0 {
+  bottom: 0px;
+}
+
 .bottom-4 {
   bottom: 1rem;
 }
 
-.bottom-\[-10\%\] {
-  bottom: -10%;
-}
-
-.left-\[-10\%\] {
-  left: -10%;
+.right-0 {
+  right: 0px;
 }
 
 .right-3 {
@@ -702,10 +704,6 @@ video {
 
 .right-4 {
   right: 1rem;
-}
-
-.right-\[-10\%\] {
-  right: -10%;
 }
 
 .top-0 {
@@ -720,20 +718,12 @@ video {
   top: 1rem;
 }
 
-.top-\[-10\%\] {
-  top: -10%;
-}
-
 .z-10 {
   z-index: 10;
 }
 
 .z-50 {
   z-index: 50;
-}
-
-.z-\[-1\] {
-  z-index: -1;
 }
 
 .mx-auto {
@@ -888,10 +878,6 @@ video {
   height: 2rem;
 }
 
-.h-\[40\%\] {
-  height: 40%;
-}
-
 .h-auto {
   height: auto;
 }
@@ -984,10 +970,6 @@ video {
   width: 2rem;
 }
 
-.w-\[40\%\] {
-  width: 40%;
-}
-
 .w-full {
   width: 100%;
 }
@@ -1041,20 +1023,9 @@ video {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
-.-skew-x-12 {
-  --tw-skew-x: -12deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
 .scale-100 {
   --tw-scale-x: 1;
   --tw-scale-y: 1;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.scale-110 {
-  --tw-scale-x: 1.1;
-  --tw-scale-y: 1.1;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
@@ -1064,30 +1035,8 @@ video {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
-.scale-\[1\.02\] {
-  --tw-scale-x: 1.02;
-  --tw-scale-y: 1.02;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
 .transform {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-@keyframes gradient-text {
-  0%, 100% {
-    background-size: 200% 200%;
-    background-position: left center;
-  }
-
-  50% {
-    background-size: 200% 200%;
-    background-position: right center;
-  }
-}
-
-.animate-gradient-text {
-  animation: gradient-text 8s ease infinite;
 }
 
 @keyframes indeterminate {
@@ -1137,6 +1086,12 @@ video {
 
 .cursor-pointer {
   cursor: pointer;
+}
+
+.appearance-none {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
 }
 
 .grid-cols-1 {
@@ -1271,8 +1226,9 @@ video {
   border-color: rgb(245 158 11 / 0.5);
 }
 
-.border-blue-500\/20 {
-  border-color: rgb(59 130 246 / 0.2);
+.border-blue-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(191 219 254 / var(--tw-border-opacity, 1));
 }
 
 .border-primary {
@@ -1284,12 +1240,14 @@ video {
   border-color: rgb(99 102 241 / 0.6);
 }
 
-.border-red-500\/30 {
-  border-color: rgb(239 68 68 / 0.3);
+.border-red-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 202 202 / var(--tw-border-opacity, 1));
 }
 
-.border-red-500\/50 {
-  border-color: rgb(239 68 68 / 0.5);
+.border-red-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(252 165 165 / var(--tw-border-opacity, 1));
 }
 
 .border-secondary {
@@ -1297,22 +1255,18 @@ video {
   border-color: rgb(236 72 153 / var(--tw-border-opacity, 1));
 }
 
-.border-slate-600 {
+.border-slate-200 {
   --tw-border-opacity: 1;
-  border-color: rgb(71 85 105 / var(--tw-border-opacity, 1));
+  border-color: rgb(226 232 240 / var(--tw-border-opacity, 1));
 }
 
-.border-slate-700 {
+.border-slate-300 {
   --tw-border-opacity: 1;
-  border-color: rgb(51 65 85 / var(--tw-border-opacity, 1));
+  border-color: rgb(203 213 225 / var(--tw-border-opacity, 1));
 }
 
 .border-transparent {
   border-color: transparent;
-}
-
-.border-white\/10 {
-  border-color: rgb(255 255 255 / 0.1);
 }
 
 .bg-accent {
@@ -1331,31 +1285,16 @@ video {
 
 .bg-background {
   --tw-bg-opacity: 1;
-  background-color: rgb(11 15 25 / var(--tw-bg-opacity, 1));
-}
-
-.bg-background\/50 {
-  background-color: rgb(11 15 25 / 0.5);
-}
-
-.bg-background\/80 {
-  background-color: rgb(11 15 25 / 0.8);
-}
-
-.bg-black\/50 {
-  background-color: rgb(0 0 0 / 0.5);
-}
-
-.bg-black\/60 {
-  background-color: rgb(0 0 0 / 0.6);
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
 }
 
 .bg-black\/80 {
   background-color: rgb(0 0 0 / 0.8);
 }
 
-.bg-blue-500\/10 {
-  background-color: rgb(59 130 246 / 0.1);
+.bg-blue-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
 }
 
 .bg-primary {
@@ -1371,8 +1310,9 @@ video {
   background-color: rgb(99 102 241 / 0.2);
 }
 
-.bg-primary\/5 {
-  background-color: rgb(99 102 241 / 0.05);
+.bg-red-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 226 226 / var(--tw-bg-opacity, 1));
 }
 
 .bg-red-400 {
@@ -1380,21 +1320,14 @@ video {
   background-color: rgb(248 113 113 / var(--tw-bg-opacity, 1));
 }
 
+.bg-red-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
+}
+
 .bg-red-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(239 68 68 / var(--tw-bg-opacity, 1));
-}
-
-.bg-red-500\/10 {
-  background-color: rgb(239 68 68 / 0.1);
-}
-
-.bg-red-500\/20 {
-  background-color: rgb(239 68 68 / 0.2);
-}
-
-.bg-red-500\/80 {
-  background-color: rgb(239 68 68 / 0.8);
 }
 
 .bg-red-600 {
@@ -1407,133 +1340,53 @@ video {
   background-color: rgb(236 72 153 / var(--tw-bg-opacity, 1));
 }
 
-.bg-secondary\/10 {
-  background-color: rgb(236 72 153 / 0.1);
-}
-
 .bg-secondary\/30 {
   background-color: rgb(236 72 153 / 0.3);
 }
 
-.bg-slate-600 {
+.bg-slate-100 {
   --tw-bg-opacity: 1;
-  background-color: rgb(71 85 105 / var(--tw-bg-opacity, 1));
+  background-color: rgb(241 245 249 / var(--tw-bg-opacity, 1));
 }
 
-.bg-slate-700 {
+.bg-slate-200 {
   --tw-bg-opacity: 1;
-  background-color: rgb(51 65 85 / var(--tw-bg-opacity, 1));
+  background-color: rgb(226 232 240 / var(--tw-bg-opacity, 1));
 }
 
-.bg-slate-800 {
+.bg-slate-50 {
   --tw-bg-opacity: 1;
-  background-color: rgb(30 41 59 / var(--tw-bg-opacity, 1));
-}
-
-.bg-slate-800\/50 {
-  background-color: rgb(30 41 59 / 0.5);
+  background-color: rgb(248 250 252 / var(--tw-bg-opacity, 1));
 }
 
 .bg-slate-800\/80 {
   background-color: rgb(30 41 59 / 0.8);
 }
 
+.bg-slate-900\/40 {
+  background-color: rgb(15 23 42 / 0.4);
+}
+
+.bg-slate-900\/50 {
+  background-color: rgb(15 23 42 / 0.5);
+}
+
 .bg-surface {
   --tw-bg-opacity: 1;
-  background-color: rgb(17 24 39 / var(--tw-bg-opacity, 1));
+  background-color: rgb(248 250 252 / var(--tw-bg-opacity, 1));
 }
 
-.bg-surface\/30 {
-  background-color: rgb(17 24 39 / 0.3);
-}
-
-.bg-surface\/50 {
-  background-color: rgb(17 24 39 / 0.5);
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
 }
 
 .bg-white\/20 {
   background-color: rgb(255 255 255 / 0.2);
 }
 
-.bg-gradient-to-br {
-  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
-}
-
-.bg-gradient-to-r {
-  background-image: linear-gradient(to right, var(--tw-gradient-stops));
-}
-
-.bg-gradient-to-t {
-  background-image: linear-gradient(to top, var(--tw-gradient-stops));
-}
-
-.from-black\/80 {
-  --tw-gradient-from: rgb(0 0 0 / 0.8) var(--tw-gradient-from-position);
-  --tw-gradient-to: rgb(0 0 0 / 0) var(--tw-gradient-to-position);
-  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-}
-
-.from-primary {
-  --tw-gradient-from: #6366F1 var(--tw-gradient-from-position);
-  --tw-gradient-to: rgb(99 102 241 / 0) var(--tw-gradient-to-position);
-  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-}
-
-.from-primary-light {
-  --tw-gradient-from: #818CF8 var(--tw-gradient-from-position);
-  --tw-gradient-to: rgb(129 140 248 / 0) var(--tw-gradient-to-position);
-  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-}
-
-.from-transparent {
-  --tw-gradient-from: transparent var(--tw-gradient-from-position);
-  --tw-gradient-to: rgb(0 0 0 / 0) var(--tw-gradient-to-position);
-  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-}
-
-.from-white {
-  --tw-gradient-from: #fff var(--tw-gradient-from-position);
-  --tw-gradient-to: rgb(255 255 255 / 0) var(--tw-gradient-to-position);
-  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-}
-
-.via-accent {
-  --tw-gradient-to: rgb(139 92 246 / 0)  var(--tw-gradient-to-position);
-  --tw-gradient-stops: var(--tw-gradient-from), #8B5CF6 var(--tw-gradient-via-position), var(--tw-gradient-to);
-}
-
-.via-transparent {
-  --tw-gradient-to: rgb(0 0 0 / 0)  var(--tw-gradient-to-position);
-  --tw-gradient-stops: var(--tw-gradient-from), transparent var(--tw-gradient-via-position), var(--tw-gradient-to);
-}
-
-.to-accent {
-  --tw-gradient-to: #8B5CF6 var(--tw-gradient-to-position);
-}
-
-.to-primary-light {
-  --tw-gradient-to: #818CF8 var(--tw-gradient-to-position);
-}
-
-.to-secondary {
-  --tw-gradient-to: #EC4899 var(--tw-gradient-to-position);
-}
-
-.to-slate-400 {
-  --tw-gradient-to: #94a3b8 var(--tw-gradient-to-position);
-}
-
-.to-transparent {
-  --tw-gradient-to: transparent var(--tw-gradient-to-position);
-}
-
-.to-white {
-  --tw-gradient-to: #fff var(--tw-gradient-to-position);
-}
-
-.bg-clip-text {
-  -webkit-background-clip: text;
-          background-clip: text;
+.bg-white\/80 {
+  background-color: rgb(255 255 255 / 0.8);
 }
 
 .object-contain {
@@ -1596,6 +1449,11 @@ video {
   padding-bottom: 0.25rem;
 }
 
+.py-1\.5 {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+}
+
 .py-2 {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
@@ -1623,6 +1481,10 @@ video {
 
 .pb-2 {
   padding-bottom: 0.5rem;
+}
+
+.pr-10 {
+  padding-right: 2.5rem;
 }
 
 .pr-12 {
@@ -1682,6 +1544,10 @@ video {
   font-weight: 500;
 }
 
+.font-normal {
+  font-weight: 400;
+}
+
 .font-semibold {
   font-weight: 600;
 }
@@ -1708,9 +1574,19 @@ video {
   color: rgb(251 191 36 / var(--tw-text-opacity, 1));
 }
 
-.text-blue-400 {
+.text-amber-600 {
   --tw-text-opacity: 1;
-  color: rgb(96 165 250 / var(--tw-text-opacity, 1));
+  color: rgb(217 119 6 / var(--tw-text-opacity, 1));
+}
+
+.text-blue-500 {
+  --tw-text-opacity: 1;
+  color: rgb(59 130 246 / var(--tw-text-opacity, 1));
+}
+
+.text-blue-600 {
+  --tw-text-opacity: 1;
+  color: rgb(37 99 235 / var(--tw-text-opacity, 1));
 }
 
 .text-primary {
@@ -1718,19 +1594,14 @@ video {
   color: rgb(99 102 241 / var(--tw-text-opacity, 1));
 }
 
-.text-red-400 {
+.text-red-600 {
   --tw-text-opacity: 1;
-  color: rgb(248 113 113 / var(--tw-text-opacity, 1));
+  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
 }
 
-.text-slate-200 {
+.text-red-700 {
   --tw-text-opacity: 1;
-  color: rgb(226 232 240 / var(--tw-text-opacity, 1));
-}
-
-.text-slate-300 {
-  --tw-text-opacity: 1;
-  color: rgb(203 213 225 / var(--tw-text-opacity, 1));
+  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
 }
 
 .text-slate-400 {
@@ -1738,23 +1609,29 @@ video {
   color: rgb(148 163 184 / var(--tw-text-opacity, 1));
 }
 
-.text-slate-50 {
-  --tw-text-opacity: 1;
-  color: rgb(248 250 252 / var(--tw-text-opacity, 1));
-}
-
 .text-slate-500 {
   --tw-text-opacity: 1;
   color: rgb(100 116 139 / var(--tw-text-opacity, 1));
 }
 
-.text-text-primary {
+.text-slate-600 {
   --tw-text-opacity: 1;
-  color: rgb(249 250 251 / var(--tw-text-opacity, 1));
+  color: rgb(71 85 105 / var(--tw-text-opacity, 1));
 }
 
-.text-transparent {
-  color: transparent;
+.text-slate-700 {
+  --tw-text-opacity: 1;
+  color: rgb(51 65 85 / var(--tw-text-opacity, 1));
+}
+
+.text-slate-900 {
+  --tw-text-opacity: 1;
+  color: rgb(15 23 42 / var(--tw-text-opacity, 1));
+}
+
+.text-text-primary {
+  --tw-text-opacity: 1;
+  color: rgb(15 23 42 / var(--tw-text-opacity, 1));
 }
 
 .text-white {
@@ -1775,22 +1652,18 @@ video {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.placeholder-slate-500::-moz-placeholder {
+.placeholder-slate-400::-moz-placeholder {
   --tw-placeholder-opacity: 1;
-  color: rgb(100 116 139 / var(--tw-placeholder-opacity, 1));
+  color: rgb(148 163 184 / var(--tw-placeholder-opacity, 1));
 }
 
-.placeholder-slate-500::placeholder {
+.placeholder-slate-400::placeholder {
   --tw-placeholder-opacity: 1;
-  color: rgb(100 116 139 / var(--tw-placeholder-opacity, 1));
+  color: rgb(148 163 184 / var(--tw-placeholder-opacity, 1));
 }
 
 .opacity-0 {
   opacity: 0;
-}
-
-.opacity-10 {
-  opacity: 0.1;
 }
 
 .opacity-100 {
@@ -1803,10 +1676,6 @@ video {
 
 .opacity-25 {
   opacity: 0.25;
-}
-
-.opacity-30 {
-  opacity: 0.3;
 }
 
 .opacity-75 {
@@ -1831,57 +1700,24 @@ video {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.shadow-primary\/20 {
-  --tw-shadow-color: rgb(99 102 241 / 0.2);
-  --tw-shadow: var(--tw-shadow-colored);
+.shadow-sm {
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.ring-1 {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-
-.ring-white\/10 {
-  --tw-ring-color: rgb(255 255 255 / 0.1);
-}
-
-.blur {
-  --tw-blur: blur(8px);
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
-.blur-\[120px\] {
-  --tw-blur: blur(120px);
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
-.blur-xl {
-  --tw-blur: blur(24px);
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
-.drop-shadow-sm {
-  --tw-drop-shadow: drop-shadow(0 1px 1px rgb(0 0 0 / 0.05));
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .filter {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
-.backdrop-blur-md {
-  --tw-backdrop-blur: blur(12px);
-  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
-}
-
 .backdrop-blur-sm {
   --tw-backdrop-blur: blur(4px);
-  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
-}
-
-.backdrop-blur-xl {
-  --tw-backdrop-blur: blur(24px);
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
 
@@ -1909,14 +1745,16 @@ video {
   transition-duration: 150ms;
 }
 
-.transition-transform {
-  transition-property: transform;
+.transition-shadow {
+  transition-property: box-shadow;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
 
-.duration-1000 {
-  transition-duration: 1000ms;
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
 }
 
 .duration-150 {
@@ -2085,33 +1923,9 @@ video {
   --tw-ring-offset-width: 2px;
 }
 
-.focus-within\:ring-offset-background:focus-within {
-  --tw-ring-offset-color: #0B0F19;
-}
-
-.hover\:-translate-y-0\.5:hover {
-  --tw-translate-y: -0.125rem;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.hover\:-translate-y-1:hover {
-  --tw-translate-y: -0.25rem;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.hover\:scale-105:hover {
-  --tw-scale-x: 1.05;
-  --tw-scale-y: 1.05;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
 .hover\:border-primary:hover {
   --tw-border-opacity: 1;
   border-color: rgb(99 102 241 / var(--tw-border-opacity, 1));
-}
-
-.hover\:border-primary\/50:hover {
-  border-color: rgb(99 102 241 / 0.5);
 }
 
 .hover\:border-red-500:hover {
@@ -2119,13 +1933,14 @@ video {
   border-color: rgb(239 68 68 / var(--tw-border-opacity, 1));
 }
 
-.hover\:border-red-500\/50:hover {
-  border-color: rgb(239 68 68 / 0.5);
+.hover\:border-slate-400:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(148 163 184 / var(--tw-border-opacity, 1));
 }
 
-.hover\:border-slate-500:hover {
-  --tw-border-opacity: 1;
-  border-color: rgb(100 116 139 / var(--tw-border-opacity, 1));
+.hover\:bg-primary-dark:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(79 70 229 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:bg-primary\/20:hover {
@@ -2136,12 +1951,9 @@ video {
   background-color: rgb(99 102 241 / 0.8);
 }
 
-.hover\:bg-red-500\/10:hover {
-  background-color: rgb(239 68 68 / 0.1);
-}
-
-.hover\:bg-red-500\/30:hover {
-  background-color: rgb(239 68 68 / 0.3);
+.hover\:bg-red-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:bg-red-600:hover {
@@ -2149,33 +1961,38 @@ video {
   background-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
 }
 
+.hover\:bg-slate-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(241 245 249 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-slate-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(248 250 252 / var(--tw-bg-opacity, 1));
+}
+
 .hover\:bg-slate-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(51 65 85 / var(--tw-bg-opacity, 1));
-}
-
-.hover\:bg-surface:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(17 24 39 / var(--tw-bg-opacity, 1));
-}
-
-.hover\:bg-surface\/50:hover {
-  background-color: rgb(17 24 39 / 0.5);
 }
 
 .hover\:bg-white\/10:hover {
   background-color: rgb(255 255 255 / 0.1);
 }
 
-.hover\:from-primary-dark:hover {
-  --tw-gradient-from: #4F46E5 var(--tw-gradient-from-position);
-  --tw-gradient-to: rgb(79 70 229 / 0) var(--tw-gradient-to-position);
-  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+.hover\:text-blue-700:hover {
+  --tw-text-opacity: 1;
+  color: rgb(29 78 216 / var(--tw-text-opacity, 1));
 }
 
-.hover\:text-blue-300:hover {
+.hover\:text-primary:hover {
   --tw-text-opacity: 1;
-  color: rgb(147 197 253 / var(--tw-text-opacity, 1));
+  color: rgb(99 102 241 / var(--tw-text-opacity, 1));
+}
+
+.hover\:text-slate-900:hover {
+  --tw-text-opacity: 1;
+  color: rgb(15 23 42 / var(--tw-text-opacity, 1));
 }
 
 .hover\:text-white:hover {
@@ -2183,20 +2000,10 @@ video {
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
 
-.hover\:shadow-xl:hover {
-  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+.hover\:shadow-md:hover {
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.hover\:shadow-primary\/30:hover {
-  --tw-shadow-color: rgb(99 102 241 / 0.3);
-  --tw-shadow: var(--tw-shadow-colored);
-}
-
-.hover\:shadow-red-500\/20:hover {
-  --tw-shadow-color: rgb(239 68 68 / 0.2);
-  --tw-shadow: var(--tw-shadow-colored);
 }
 
 .focus\:border-primary:focus {
@@ -2220,8 +2027,8 @@ video {
   --tw-ring-color: rgb(99 102 241 / var(--tw-ring-opacity, 1));
 }
 
-.focus\:ring-primary\/50:focus {
-  --tw-ring-color: rgb(99 102 241 / 0.5);
+.focus\:ring-primary\/30:focus {
+  --tw-ring-color: rgb(99 102 241 / 0.3);
 }
 
 .focus\:ring-red-500:focus {
@@ -2235,20 +2042,6 @@ video {
 
 .focus\:ring-offset-2:focus {
   --tw-ring-offset-width: 2px;
-}
-
-.focus\:ring-offset-background:focus {
-  --tw-ring-offset-color: #0B0F19;
-}
-
-.focus\:ring-offset-surface:focus {
-  --tw-ring-offset-color: #111827;
-}
-
-.active\:scale-95:active {
-  --tw-scale-x: .95;
-  --tw-scale-y: .95;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
 .disabled\:cursor-not-allowed:disabled {
@@ -2275,30 +2068,8 @@ video {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
-@keyframes shine {
-  100% {
-    left: 125%;
-  }
-}
-
-.group:hover .group-hover\:animate-shine {
-  animation: shine 1.5s infinite;
-}
-
-.group:hover .group-hover\:to-white {
-  --tw-gradient-to: #fff var(--tw-gradient-to-position);
-}
-
 .group:hover .group-hover\:opacity-100 {
   opacity: 1;
-}
-
-.group:hover .group-hover\:opacity-50 {
-  opacity: 0.5;
-}
-
-.group:hover .group-hover\:duration-200 {
-  transition-duration: 200ms;
 }
 
 @media (min-width: 640px) {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ current_language }}" class="dark">
+<html lang="{{ current_language }}">
 
 <head>
     <meta charset="UTF-8">
@@ -39,27 +39,20 @@
 
 <body x-data="{ ...apiKeyManager(), ...languageSwitcher() }"
     class="bg-background text-text-primary min-h-screen flex flex-col font-sans antialiased selection:bg-primary selection:text-white overflow-x-hidden">
-    <!-- Background Effects -->
-    <div class="fixed inset-0 z-[-1] overflow-hidden pointer-events-none">
-        <div class="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] rounded-full bg-primary/20 blur-[120px]"></div>
-        <div class="absolute bottom-[-10%] right-[-10%] w-[40%] h-[40%] rounded-full bg-secondary/10 blur-[120px]">
-        </div>
-    </div>
     <!-- Header -->
     <header
-        class="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-white/10 transition-all duration-300">
+        class="sticky top-0 z-50 bg-background border-b border-slate-200 transition-all duration-300">
         <nav class="container mx-auto px-4 py-4 flex justify-between items-center">
             <a href="/" class="group flex items-center gap-2">
                 <div
-                    class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-accent flex items-center justify-center transform group-hover:rotate-12 transition-transform duration-300">
+                    class="w-8 h-8 rounded-lg bg-primary flex items-center justify-center transform group-hover:rotate-12 transition-transform duration-300">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-white" fill="none" viewBox="0 0 24 24"
                         stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                             d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
                     </svg>
                 </div>
-                <span
-                    class="text-xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-white to-slate-400 group-hover:to-white transition-all duration-300">
+                <span class="text-xl font-bold text-slate-900">
                     Menu Judge
                 </span>
             </a>
@@ -67,13 +60,13 @@
             <div class="flex items-center gap-3">
                 <!-- Language Switcher -->
                 <button @click="toggleLanguage()" type="button"
-                    class="flex items-center gap-2 rounded-lg border border-white/10 bg-surface/50 px-3 py-2 text-sm font-medium text-slate-300 backdrop-blur-sm transition-all hover:border-primary/50 hover:bg-surface hover:text-white focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background">
+                    class="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2">
                     <span x-text="getLanguageFlag()"></span>
                     <span x-text="getLanguageLabel()" class="hidden sm:inline"></span>
                 </button>
                 <!-- Settings Button -->
                 <button @click="openModal()" type="button"
-                class="group relative flex items-center gap-2 rounded-lg border border-white/10 bg-surface/50 px-4 py-2 text-sm font-medium text-slate-300 backdrop-blur-sm transition-all hover:border-primary/50 hover:bg-surface hover:text-white focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background">
+                class="group relative flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2">
                 <svg class="h-5 w-5 transition-transform group-hover:rotate-90 duration-500" fill="none"
                     stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -98,7 +91,7 @@
     </main>
 
     <!-- Footer -->
-    <footer class="border-t border-white/10 mt-auto bg-background/50 backdrop-blur-sm">
+    <footer class="border-t border-slate-200 mt-auto bg-background">
         <div class="container mx-auto px-4 py-6 text-center text-slate-500 text-sm">
             &copy; {{ now().year }} Menu Judge. All rights reserved.
         </div>

--- a/app/templates/components/api_key_modal.html
+++ b/app/templates/components/api_key_modal.html
@@ -9,7 +9,7 @@
      @keydown="FocusTrap.handleTab($event, $refs.modalContent)"
      x-ref="modalContainer">
     <!-- Overlay -->
-    <div class="fixed inset-0 bg-black/60 backdrop-blur-sm transition-opacity" @click="closeModal()"
+    <div class="fixed inset-0 bg-slate-900/40 transition-opacity" @click="closeModal()"
         x-show="showModal" x-transition:enter="transition ease-out duration-300"
         x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
         x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100"
@@ -19,7 +19,7 @@
 
     <!-- Modal Content -->
     <div class="flex min-h-screen items-center justify-center p-4">
-        <div class="relative w-full max-w-md transform overflow-hidden rounded-2xl bg-surface shadow-2xl ring-1 ring-white/10 transition-all"
+        <div class="relative w-full max-w-md transform overflow-hidden rounded-2xl bg-white shadow-xl border border-slate-200 transition-all"
             x-show="showModal"
             x-transition:enter="transition ease-out duration-300"
             x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
@@ -30,10 +30,10 @@
             @click.stop>
 
             <!-- Header -->
-            <div class="bg-gradient-to-r from-primary to-accent p-6">
+            <div class="bg-primary p-6">
                 <div class="flex items-center justify-between">
                     <div class="flex items-center gap-3">
-                        <div class="rounded-lg bg-white/20 p-2 backdrop-blur-sm">
+                        <div class="rounded-lg bg-white/20 p-2">
                             <svg class="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z">
@@ -57,24 +57,24 @@
             <!-- Body -->
             <div class="p-6 space-y-6">
                 <!-- Description -->
-                <div class="rounded-lg bg-blue-500/10 border border-blue-500/20 p-4">
+                <div class="rounded-lg bg-blue-50 border border-blue-200 p-4">
                     <div class="flex gap-3">
-                        <svg class="h-5 w-5 flex-shrink-0 text-blue-400 mt-0.5" fill="none" stroke="currentColor"
+                        <svg class="h-5 w-5 flex-shrink-0 text-blue-500 mt-0.5" fill="none" stroke="currentColor"
                             viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                 d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                         </svg>
-                        <div class="text-sm text-slate-300 space-y-2">
+                        <div class="text-sm text-slate-700 space-y-2">
                             <p x-text="t('api_key_modal.description', 'Menu analysis requires an AI API.')"></p>
                             <p>
                                 <span x-text="t('api_key_modal.get_key_text', 'You can get your API key from')"></span>
                                 <a :href="getProviderConsoleUrl(selectedProvider)" target="_blank"
                                     rel="noopener noreferrer"
-                                    class="text-blue-400 hover:text-blue-300 underline">
+                                    class="text-blue-600 hover:text-blue-700 underline">
                                     <span x-text="providers.find(p => p.id === selectedProvider)?.name || 'Provider Console'"></span>
                                 </a>.
                             </p>
-                            <p class="text-xs text-slate-400" x-text="t('api_key_modal.storage_notice')"></p>
+                            <p class="text-xs text-slate-500" x-text="t('api_key_modal.storage_notice')"></p>
                         </div>
                     </div>
                 </div>
@@ -82,14 +82,14 @@
                 <!-- Provider Selection -->
                 <div class="space-y-4">
                     <div>
-                        <label for="provider-select" class="block text-sm font-medium text-slate-300 mb-2"
+                        <label for="provider-select" class="block text-sm font-medium text-slate-700 mb-2"
                             x-text="t('api_key_modal.provider_label', 'AI Provider')">
                         </label>
                         <div class="relative">
                             <select id="provider-select"
                                 x-model="selectedProvider"
                                 @change="changeProvider($event.target.value)"
-                                class="w-full appearance-none rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 pr-10 text-white focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50 transition-all cursor-pointer">
+                                class="w-full appearance-none rounded-lg border border-slate-300 bg-white px-4 py-3 pr-10 text-slate-900 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors cursor-pointer">
                                 <template x-for="provider in providers" :key="provider.id">
                                     <option :value="provider.id" x-text="provider.name + (provider.implemented ? '' : ' (Coming Soon)')"></option>
                                 </template>
@@ -102,7 +102,7 @@
                         </div>
                         <!-- Provider not implemented warning -->
                         <p x-show="!isProviderImplemented(selectedProvider)"
-                           class="mt-2 text-xs text-amber-400 flex items-center gap-1">
+                           class="mt-2 text-xs text-amber-600 flex items-center gap-1">
                             <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                     d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
@@ -113,16 +113,16 @@
 
                     <!-- API Key Input Form -->
                     <div>
-                        <label for="api-key-input" class="block text-sm font-medium text-slate-300 mb-2"
+                        <label for="api-key-input" class="block text-sm font-medium text-slate-700 mb-2"
                             x-text="t('api_key_modal.input_label', 'API Key')">
                         </label>
                         <div class="relative">
                             <input :type="showApiKey ? 'text' : 'password'" id="api-key-input" x-model="apiKeyInput"
                                 :placeholder="getProviderPlaceholder(selectedProvider)"
-                                class="w-full rounded-lg border border-slate-600 bg-slate-800 px-4 py-3 pr-12 text-white placeholder-slate-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50 transition-all"
+                                class="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 pr-12 text-slate-900 placeholder-slate-400 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
                                 @keydown.enter="saveApiKey(apiKeyInput)">
                             <button @click="showApiKey = !showApiKey" type="button"
-                                class="absolute right-3 top-1/2 -translate-y-1/2 rounded p-1 text-slate-400 hover:text-white transition-colors">
+                                class="absolute right-3 top-1/2 -translate-y-1/2 rounded p-1 text-slate-500 hover:text-slate-900 transition-colors">
                                 <svg x-show="!showApiKey" class="h-5 w-5" fill="none" stroke="currentColor"
                                     viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -144,11 +144,11 @@
                     <!-- Button Area -->
                     <div class="flex gap-3">
                         <button @click="saveApiKey(apiKeyInput)" type="button"
-                            class="flex-1 rounded-lg bg-gradient-to-r from-primary to-accent px-4 py-3 font-semibold text-white shadow-lg transition-all hover:shadow-primary/30 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-surface"
+                            class="flex-1 rounded-lg bg-primary hover:bg-primary-dark px-4 py-3 font-semibold text-white shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
                             x-text="t('api_key_modal.save_button', 'Save')">
                         </button>
                         <button @click="deleteApiKey()" type="button" x-show="apiKey"
-                            class="rounded-lg border border-red-500/50 px-4 py-3 font-semibold text-red-400 transition-all hover:bg-red-500/10 hover:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-surface"
+                            class="rounded-lg border border-red-300 px-4 py-3 font-semibold text-red-600 transition-colors hover:bg-red-50 hover:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
                             x-text="t('api_key_modal.delete_button', 'Delete')">
                         </button>
                     </div>

--- a/app/templates/components/dish_card.html
+++ b/app/templates/components/dish_card.html
@@ -11,9 +11,9 @@ Arguments:
 #}
 
 {% macro dish_card(dish, index=none) %}
-<div class="dish-card bg-surface rounded-xl p-4 shadow-lg
-            hover:shadow-xl transition-all duration-300
-            border border-slate-700 hover:border-primary relative
+<div class="dish-card bg-white rounded-xl p-4 shadow-sm
+            hover:shadow-md transition-shadow duration-200
+            border border-slate-200 hover:border-primary relative
             {% if index %}pt-6{% endif %}"
     {% if index %}
     @mouseenter="window.dispatchEvent(new CustomEvent('highlight-dish', { detail: { index: {{ index }} }}))"
@@ -24,7 +24,7 @@ Arguments:
     {% if index %}
     <div class="absolute -top-3 -left-3 w-8 h-8 rounded-full bg-primary
                 flex items-center justify-center text-white font-bold text-sm
-                shadow-lg z-10">
+                shadow-sm z-10">
         {{ index }}
     </div>
     {% endif %}
@@ -34,14 +34,14 @@ Arguments:
         <div class="flex-1 min-w-0">
             <!-- カテゴリバッジをタイトル上に移動 -->
             {% if dish.category %}
-            <span class="inline-block px-2 py-0.5 bg-primary/20 text-primary rounded text-xs mb-1">
+            <span class="inline-block px-2 py-0.5 bg-primary/10 text-primary rounded text-xs mb-1">
                 {{ dish.category.value }}
             </span>
             {% endif %}
-            <h3 class="text-lg font-bold text-slate-50 leading-tight">
+            <h3 class="text-lg font-bold text-slate-900 leading-tight">
                 {{ dish.translated_name }}
             </h3>
-            <p class="text-sm text-slate-400">
+            <p class="text-sm text-slate-500">
                 {{ dish.original_name }}
             </p>
         </div>
@@ -49,7 +49,7 @@ Arguments:
 
     <!-- Description -->
     {% if dish.description %}
-    <p class="text-slate-300 text-sm mb-3 line-clamp-3">
+    <p class="text-slate-700 text-sm mb-3 line-clamp-3">
         {{ dish.description }}
     </p>
     {% endif %}
@@ -62,7 +62,7 @@ Arguments:
             <span class="text-sm">🌶️</span>
             {% for i in range(5) %}
                 <span class="w-2 h-2 rounded-full
-                    {% if i < dish.spiciness %}bg-red-500{% else %}bg-slate-600{% endif %}">
+                    {% if i < dish.spiciness %}bg-red-500{% else %}bg-slate-200{% endif %}">
                 </span>
             {% endfor %}
         </div>
@@ -72,7 +72,7 @@ Arguments:
             <span class="text-sm">🍯</span>
             {% for i in range(5) %}
                 <span class="w-2 h-2 rounded-full
-                    {% if i < dish.sweetness %}bg-amber-500{% else %}bg-slate-600{% endif %}">
+                    {% if i < dish.sweetness %}bg-amber-500{% else %}bg-slate-200{% endif %}">
                 </span>
             {% endfor %}
         </div>
@@ -84,7 +84,7 @@ Arguments:
     {% if dish.ingredients %}
     <div class="flex flex-wrap gap-1 mb-3">
         {% for ingredient in dish.ingredients %}
-        <span class="px-2 py-0.5 bg-slate-700 rounded-full text-xs text-slate-300">
+        <span class="px-2 py-0.5 bg-slate-100 rounded-full text-xs text-slate-700">
             {{ ingredient }}
         </span>
         {% endfor %}
@@ -93,8 +93,8 @@ Arguments:
 
     <!-- Allergy Warning -->
     {% if dish.allergens %}
-    <div class="p-2 bg-red-500/10 border border-red-500/30 rounded">
-        <p class="text-xs text-red-400">
+    <div class="p-2 bg-red-50 border border-red-200 rounded">
+        <p class="text-xs text-red-600">
             ⚠️ {{ t('dish_card.allergens_label', 'Allergens:') }} {{ dish.allergens | join(', ') }}
         </p>
     </div>

--- a/app/templates/components/image_with_boxes.html
+++ b/app/templates/components/image_with_boxes.html
@@ -46,8 +46,8 @@
 
     <!-- 画像がない場合のフォールバック -->
     <template x-if="!getImageUrl()">
-        <div class="bg-surface rounded-xl p-8 text-center border border-slate-700">
-            <p class="text-slate-400">画像が読み込まれていません</p>
+        <div class="bg-slate-50 rounded-xl p-8 text-center border border-slate-200">
+            <p class="text-slate-500">画像が読み込まれていません</p>
         </div>
     </template>
 </div>

--- a/app/templates/components/loading.html
+++ b/app/templates/components/loading.html
@@ -21,25 +21,18 @@ Features:
 
     <!-- Spinner -->
     <div class="relative mb-6">
-        <div class="absolute inset-0 bg-primary blur-xl opacity-30 animate-pulse"></div>
         <svg class="animate-spin h-16 w-16 text-primary" viewBox="0 0 24 24" aria-hidden="true" fill="none">
-            <defs>
-                <linearGradient id="spinner-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-                    <stop offset="0%" stop-color="#6366F1" />
-                    <stop offset="100%" stop-color="#EC4899" />
-                </linearGradient>
-            </defs>
-            <circle class="opacity-10" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-            <path class="opacity-100" stroke="url(#spinner-gradient)" stroke-width="4" stroke-linecap="round"
+            <circle class="opacity-20" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path class="opacity-100" stroke="currentColor" stroke-width="4" stroke-linecap="round"
                 d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
         </svg>
     </div>
 
     <!-- Progressive Messages -->
-    <h3 class="text-xl font-bold text-white mb-2 transition-all duration-300"
+    <h3 class="text-xl font-bold text-slate-900 mb-2 transition-all duration-300"
         x-text="currentMessage">
     </h3>
-    <p class="text-slate-400 font-medium transition-opacity duration-300"
+    <p class="text-slate-600 font-medium transition-opacity duration-300"
        x-text="currentSubMessage">
     </p>
 
@@ -53,8 +46,8 @@ Features:
     <span class="sr-only" x-text="currentMessage + '. ' + t('loading.please_wait', 'Please wait a moment.')"></span>
 
     <!-- Progress bar (indeterminate animation) -->
-    <div class="mt-8 w-64 h-2 bg-slate-800 rounded-full overflow-hidden">
-        <div class="h-full w-1/3 bg-gradient-to-r from-primary via-accent to-secondary rounded-full animate-indeterminate">
+    <div class="mt-8 w-64 h-2 bg-slate-200 rounded-full overflow-hidden">
+        <div class="h-full w-1/3 bg-primary rounded-full animate-indeterminate">
         </div>
     </div>
 

--- a/app/templates/components/skeleton_card.html
+++ b/app/templates/components/skeleton_card.html
@@ -13,38 +13,38 @@ Features:
 #}
 
 {% macro skeleton_card() %}
-<div class="skeleton-card bg-surface rounded-xl p-4 shadow-lg border border-slate-700 animate-pulse"
+<div class="skeleton-card bg-white rounded-xl p-4 shadow-sm border border-slate-200 animate-pulse"
      aria-hidden="true">
     <!-- Header skeleton -->
     <div class="flex justify-between items-start mb-3">
         <div class="flex-1">
-            <div class="h-5 bg-slate-700 rounded w-3/4 mb-2"></div>
-            <div class="h-4 bg-slate-800 rounded w-1/2"></div>
+            <div class="h-5 bg-slate-200 rounded w-3/4 mb-2"></div>
+            <div class="h-4 bg-slate-100 rounded w-1/2"></div>
         </div>
-        <div class="h-6 w-12 bg-slate-700 rounded"></div>
+        <div class="h-6 w-12 bg-slate-200 rounded"></div>
     </div>
 
     <!-- Description skeleton -->
     <div class="space-y-2 mb-3">
-        <div class="h-3 bg-slate-800 rounded w-full"></div>
-        <div class="h-3 bg-slate-800 rounded w-5/6"></div>
+        <div class="h-3 bg-slate-100 rounded w-full"></div>
+        <div class="h-3 bg-slate-100 rounded w-5/6"></div>
     </div>
 
     <!-- Indicators skeleton -->
     <div class="flex gap-4 mb-3">
         <div class="flex items-center gap-1">
-            <div class="w-4 h-4 bg-slate-700 rounded"></div>
+            <div class="w-4 h-4 bg-slate-200 rounded"></div>
             <div class="flex gap-1">
                 {% for i in range(5) %}
-                <div class="w-2 h-2 bg-slate-700 rounded-full"></div>
+                <div class="w-2 h-2 bg-slate-200 rounded-full"></div>
                 {% endfor %}
             </div>
         </div>
         <div class="flex items-center gap-1">
-            <div class="w-4 h-4 bg-slate-700 rounded"></div>
+            <div class="w-4 h-4 bg-slate-200 rounded"></div>
             <div class="flex gap-1">
                 {% for i in range(5) %}
-                <div class="w-2 h-2 bg-slate-700 rounded-full"></div>
+                <div class="w-2 h-2 bg-slate-200 rounded-full"></div>
                 {% endfor %}
             </div>
         </div>
@@ -52,15 +52,15 @@ Features:
 
     <!-- Tags skeleton -->
     <div class="flex flex-wrap gap-1 mb-3">
-        <div class="h-5 w-16 bg-slate-700 rounded-full"></div>
-        <div class="h-5 w-12 bg-slate-700 rounded-full"></div>
-        <div class="h-5 w-20 bg-slate-700 rounded-full"></div>
-        <div class="h-5 w-14 bg-slate-700 rounded-full"></div>
+        <div class="h-5 w-16 bg-slate-200 rounded-full"></div>
+        <div class="h-5 w-12 bg-slate-200 rounded-full"></div>
+        <div class="h-5 w-20 bg-slate-200 rounded-full"></div>
+        <div class="h-5 w-14 bg-slate-200 rounded-full"></div>
     </div>
 
     <!-- Category skeleton -->
     <div class="mt-3">
-        <div class="h-5 w-20 bg-slate-700 rounded"></div>
+        <div class="h-5 w-20 bg-slate-200 rounded"></div>
     </div>
 </div>
 {% endmacro %}
@@ -69,8 +69,8 @@ Features:
 <div class="skeleton-grid" aria-busy="true" aria-label="{{ t('ui.loading', 'Loading...') }}">
     <!-- Results Header skeleton -->
     <div class="flex justify-between items-center mb-4 animate-pulse">
-        <div class="h-7 w-48 bg-slate-700 rounded"></div>
-        <div class="h-5 w-32 bg-slate-800 rounded"></div>
+        <div class="h-7 w-48 bg-slate-200 rounded"></div>
+        <div class="h-5 w-32 bg-slate-100 rounded"></div>
     </div>
 
     <!-- Grid of skeleton cards -->

--- a/app/templates/components/upload_zone.html
+++ b/app/templates/components/upload_zone.html
@@ -20,11 +20,10 @@ Features:
     <div class="mb-6 grid grid-cols-1 sm:grid-cols-2 gap-3">
         <!-- Camera Capture Button -->
         <label class="group cursor-pointer flex items-center justify-center gap-3
-                      bg-gradient-to-r from-primary to-primary-light text-white
+                      bg-primary hover:bg-primary-dark text-white
                       font-semibold py-4 px-6 rounded-xl
-                      shadow-lg hover:shadow-xl shadow-primary/20
-                      active:scale-95 transition-all duration-200
-                      focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2 focus-within:ring-offset-background">
+                      shadow-sm transition-colors duration-200
+                      focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2">
             <input type="file" name="image" accept="image/*" capture="environment"
                    aria-label="{{ t('ui.take_photo', 'Take Photo') }}"
                    @change="handleFileSelect($event)" class="sr-only">
@@ -40,11 +39,11 @@ Features:
 
         <!-- Quick File Select Button -->
         <label class="group cursor-pointer flex items-center justify-center gap-3
-                      bg-surface border-2 border-slate-600 text-slate-200
+                      bg-white border-2 border-slate-300 text-slate-700
                       font-semibold py-4 px-6 rounded-xl
-                      hover:bg-slate-700 hover:border-slate-500
-                      active:scale-95 transition-all duration-200
-                      focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2 focus-within:ring-offset-background">
+                      hover:bg-slate-50 hover:border-slate-400
+                      transition-colors duration-200
+                      focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2">
             <input type="file" name="image" accept=".jpg,.jpeg,.png,.webp"
                    aria-label="{{ t('ui.choose_file', 'Choose File') }}"
                    @change="handleFileSelect($event)" class="sr-only">
@@ -59,10 +58,10 @@ Features:
 
     <!-- Drag & Drop Area -->
     <div class="drop-zone border-2 border-dashed rounded-xl p-6 text-center
-                transition-all duration-300 relative overflow-hidden cursor-pointer"
+                transition-colors duration-200 relative overflow-hidden cursor-pointer"
         :class="isDragging
-            ? 'border-primary bg-primary/10 scale-[1.02]'
-            : 'border-slate-600 bg-surface/30 hover:border-slate-500 hover:bg-surface/50'"
+            ? 'border-primary bg-primary/10'
+            : 'border-slate-300 bg-white hover:border-slate-400 hover:bg-slate-50'"
         @dragenter.prevent="isDragging = true"
         @dragover.prevent="isDragging = true"
         @dragleave.prevent="isDragging = false"
@@ -81,8 +80,8 @@ Features:
 
         <!-- Drop Zone Content -->
         <div class="flex flex-col items-center gap-3 pointer-events-none">
-            <div class="w-16 h-16 rounded-full bg-slate-800/50 border border-slate-600 flex items-center justify-center transition-all duration-300"
-                :class="isDragging ? 'scale-110 border-primary bg-primary/20 text-primary' : 'text-slate-400'">
+            <div class="w-16 h-16 rounded-full bg-slate-100 border border-slate-200 flex items-center justify-center transition-colors duration-200"
+                :class="isDragging ? 'border-primary bg-primary/20 text-primary' : 'text-slate-500'">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
@@ -91,8 +90,8 @@ Features:
             </div>
 
             <div class="space-y-1">
-                <p class="text-lg font-medium transition-colors duration-300"
-                   :class="isDragging ? 'text-primary' : 'text-slate-300'"
+                <p class="text-lg font-medium transition-colors duration-200"
+                   :class="isDragging ? 'text-primary' : 'text-slate-700'"
                    x-text="isDragging ? t('ui.drop_here', 'Drop here!') : t('ui.drag_drop', 'Drag & drop image here')">
                 </p>
                 <p class="text-sm text-slate-500">
@@ -100,25 +99,20 @@ Features:
                 </p>
             </div>
         </div>
-
-        <!-- Drag Overlay Effect -->
-        <div class="absolute inset-0 bg-primary/5 transition-opacity duration-300 pointer-events-none"
-             :class="isDragging ? 'opacity-100' : 'opacity-0'">
-        </div>
     </div>
 
     <!-- Preview -->
     <div x-show="preview" x-transition:enter="transition ease-out duration-300"
         x-transition:enter-start="opacity-0 translateY-4" x-transition:enter-end="opacity-100 translateY-0"
         class="mt-6">
-        <div class="relative group rounded-xl overflow-hidden border border-white/10 shadow-2xl">
+        <div class="relative group rounded-xl overflow-hidden border border-slate-200 shadow-sm">
             <img :src="preview" :alt="'Preview: ' + (file?.name || 'Uploaded image')"
-                class="w-full h-auto max-h-[400px] object-contain bg-black/50 backdrop-blur-sm">
+                class="w-full h-auto max-h-[400px] object-contain bg-slate-50">
 
             <div
-                class="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-end justify-center p-6">
+                class="absolute inset-x-0 bottom-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-end justify-center p-6">
                 <button @click="clearFile" type="button"
-                    class="bg-red-500/80 hover:bg-red-600 backdrop-blur-md text-white px-6 py-2 rounded-full font-medium shadow-lg hover:shadow-red-500/20 transition-all transform hover:scale-105 flex items-center gap-2">
+                    class="bg-red-500 hover:bg-red-600 text-white px-6 py-2 rounded-full font-medium shadow-sm transition-colors flex items-center gap-2">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24"
                         stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,26 +8,20 @@
     <!-- Hero Section -->
     <section class="max-w-4xl mx-auto text-center mb-12">
         <h1 class="text-5xl md:text-7xl font-extrabold mb-6 tracking-tight leading-tight">
-            <span class="block text-white drop-shadow-sm">{{ t('ui.hero_title') }}</span>
-            <span
-                class="pb-2 bg-clip-text text-transparent bg-gradient-to-r from-primary-light via-accent to-secondary animate-gradient-text">
+            <span class="block text-slate-900">{{ t('ui.hero_title') }}</span>
+            <span class="pb-2 text-primary">
                 {{ t('ui.hero_subtitle') }}
             </span>
         </h1>
-        <p class="text-lg md:text-xl text-slate-300 max-w-2xl mx-auto leading-relaxed">
+        <p class="text-lg md:text-xl text-slate-600 max-w-2xl mx-auto leading-relaxed">
             {{ t('ui.hero_description') }}<br class="hidden md:inline">
             {{ t('ui.hero_description_line2') }}
         </p>
     </section>
 
     <!-- Upload Section -->
-    <section class="max-w-xl mx-auto w-full relative group">
-        <!-- Glow Effect -->
-        <div
-            class="absolute -inset-1 bg-gradient-to-r from-primary to-secondary rounded-2xl blur opacity-25 group-hover:opacity-50 transition duration-1000 group-hover:duration-200 pointer-events-none">
-        </div>
-
-        <div class="relative bg-surface/50 backdrop-blur-xl ring-1 ring-white/10 rounded-xl p-8 shadow-2xl">
+    <section class="max-w-xl mx-auto w-full relative">
+        <div class="relative bg-surface border border-slate-200 rounded-xl p-8 shadow-md">
             <form hx-post="{{ url_for('menu.analyze_menu') }}" hx-target="#result-area" hx-swap="innerHTML"
                 hx-indicator="#loading" hx-encoding="multipart/form-data" @htmx:before-request="analyzing = true"
                 @htmx:after-request="analyzing = false">
@@ -38,12 +32,7 @@
                 <!-- Analyze Button -->
                 <div class="mt-8 text-center">
                     <button type="submit" :disabled="analyzing"
-                        class="group relative w-full flex items-center justify-center py-4 px-8 border border-transparent text-lg font-bold rounded-xl text-white bg-gradient-to-r from-primary to-accent hover:from-primary-dark hover:to-accent-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed shadow-lg hover:shadow-primary/30 transition-all duration-300 transform hover:-translate-y-1 overflow-hidden">
-
-                        <!-- Shine effect -->
-                        <div
-                            class="absolute top-0 -inset-full h-full w-1/2 z-5 block transform -skew-x-12 bg-gradient-to-r from-transparent to-white opacity-20 group-hover:animate-shine pointer-events-none">
-                        </div>
+                        class="relative w-full flex items-center justify-center py-4 px-8 border border-transparent text-lg font-bold rounded-xl text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed shadow-sm transition-colors duration-200">
 
                         <span x-show="!analyzing" class="flex items-center gap-2 relative z-10">
                             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -73,7 +62,7 @@
 
     <!-- Loading Overlay -->
     <div id="loading"
-        class="htmx-indicator fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+        class="htmx-indicator fixed inset-0 z-50 flex items-center justify-center bg-white/80 backdrop-blur-sm">
         {% include 'components/loading.html' %}
     </div>
 

--- a/app/templates/partials/dish_list.html
+++ b/app/templates/partials/dish_list.html
@@ -32,9 +32,9 @@ Arguments:
      }">
     <!-- Results Summary -->
     <div class="flex flex-wrap justify-between items-center gap-2 mb-4">
-        <h2 class="text-xl font-bold">
+        <h2 class="text-xl font-bold text-slate-900">
             {{ t('results.title', 'Analysis Results') }}
-            <span class="text-sm text-slate-400">
+            <span class="text-sm text-slate-500 font-normal">
                 (<span data-testid="filtered-count" x-text="filteredCount">{{ dishes | length }}</span> {{ t('results.dish_count', 'dishes') }})
             </span>
         </h2>
@@ -43,7 +43,7 @@ Arguments:
             <!-- View Menu Image Button -->
             <button
                 @click="showImageModal = true"
-                class="px-4 py-2 bg-primary hover:bg-primary/80 text-white rounded-lg
+                class="px-4 py-2 bg-primary hover:bg-primary-dark text-white rounded-lg
                        transition-colors flex items-center gap-2 text-sm"
                 aria-label="{{ t('results.view_menu_image', 'View Menu Image') }}"
             >
@@ -54,7 +54,7 @@ Arguments:
                 {{ t('results.view_menu_image', 'View Menu Image') }}
             </button>
             {% endif %}
-            <span class="text-sm text-slate-400">
+            <span class="text-sm text-slate-500">
                 {{ t('results.analyzed_with', 'Analyzed with') }} {{ provider }} | {{ "%.2f"|format(processing_time) }}s
             </span>
         </div>
@@ -77,7 +77,7 @@ Arguments:
             :aria-selected="selectedCategory === 'all'"
             :class="selectedCategory === 'all'
                     ? 'bg-primary text-white border-primary'
-                    : 'bg-slate-800 text-slate-300 border-slate-700 hover:border-primary'"
+                    : 'bg-white text-slate-700 border-slate-300 hover:border-primary'"
             class="px-3 py-1.5 rounded-lg text-sm border transition-colors"
         >
             {{ t('results.filter_all', 'All') }} ({{ dishes | length }})
@@ -92,7 +92,7 @@ Arguments:
             :aria-selected="selectedCategory === '{{ cat }}'"
             :class="selectedCategory === '{{ cat }}'
                     ? 'bg-primary text-white border-primary'
-                    : 'bg-slate-800 text-slate-300 border-slate-700 hover:border-primary'"
+                    : 'bg-white text-slate-700 border-slate-300 hover:border-primary'"
             class="px-3 py-1.5 rounded-lg text-sm border transition-colors"
         >
             {{ t('results.filter_category_' ~ cat, cat) }} ({{ cnt }})
@@ -124,7 +124,7 @@ Arguments:
         x-transition:leave="transition ease-in duration-150"
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
-        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/50"
         @click.self="showImageModal = false"
         @keydown.escape.window="showImageModal = false"
         @keydown="FocusTrap.handleTab($event, $refs.imageModalContent)"
@@ -134,14 +134,14 @@ Arguments:
         x-ref="imageModalContainer"
     >
         <!-- Modal Content -->
-        <div class="relative w-full max-w-[95vw] md:max-w-4xl max-h-[90vh] overflow-auto bg-surface rounded-xl shadow-2xl"
+        <div class="relative w-full max-w-[95vw] md:max-w-4xl max-h-[90vh] overflow-auto bg-white rounded-xl shadow-xl border border-slate-200"
              x-ref="imageModalContent"
              x-init="$watch('showImageModal', value => { if (value) FocusTrap.setInitialFocus($refs.imageModalContent) })">
             <!-- Close Button -->
             <button
                 @click="showImageModal = false"
-                class="absolute top-4 right-4 z-10 p-2 bg-slate-800/80 hover:bg-slate-700
-                       rounded-full text-white transition-colors"
+                class="absolute top-4 right-4 z-10 p-2 bg-white hover:bg-slate-100 border border-slate-200
+                       rounded-full text-slate-700 transition-colors shadow-sm"
                 aria-label="{{ t('api_key_modal.close_modal', 'Close') }}"
             >
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -164,7 +164,7 @@ Arguments:
     <!-- No Dishes Found -->
     {% if not dishes %}
     <div class="text-center py-8">
-        <p class="text-slate-400">{{ t('results.no_dishes_detected', 'No dishes detected') }}</p>
+        <p class="text-slate-600">{{ t('results.no_dishes_detected', 'No dishes detected') }}</p>
         <p class="text-sm text-slate-500">
             {{ t('results.try_different_image', 'Please try a different image') }}
         </p>

--- a/app/templates/partials/error.html
+++ b/app/templates/partials/error.html
@@ -1,11 +1,11 @@
 <div id="error-message"
      role="alert"
      aria-live="assertive"
-     class="bg-red-500/10 border border-red-500/30 rounded-xl p-6 animate-shake max-w-xl mx-auto">
+     class="bg-red-50 border border-red-200 rounded-xl p-6 animate-shake max-w-xl mx-auto">
     <div class="flex items-start gap-4">
         <!-- Error Icon -->
-        <div class="flex-shrink-0 w-12 h-12 rounded-full bg-red-500/20 flex items-center justify-center">
-            <svg class="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div class="flex-shrink-0 w-12 h-12 rounded-full bg-red-100 flex items-center justify-center">
+            <svg class="w-6 h-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                       d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
@@ -13,27 +13,27 @@
 
         <div class="flex-1">
             <!-- Error Title -->
-            <h3 class="font-bold text-red-400 text-lg">
+            <h3 class="font-bold text-red-700 text-lg">
                 {{ title | default(t('error.title', 'An Error Occurred')) }}
             </h3>
 
             <!-- Error Message -->
-            <p class="text-sm text-slate-300 mt-2 leading-relaxed">
+            <p class="text-sm text-slate-700 mt-2 leading-relaxed">
                 {{ message }}
             </p>
 
             <!-- Error Code -->
             {% if code %}
-            <p class="text-xs text-slate-500 mt-3 font-mono bg-slate-800/50 px-2 py-1 rounded inline-block">
+            <p class="text-xs text-slate-500 mt-3 font-mono bg-slate-100 px-2 py-1 rounded inline-block">
                 {{ t('error.error_code', 'Error Code:') }} {{ code }}
             </p>
             {% endif %}
 
             <!-- Close Button -->
             <div class="mt-4">
-                <button class="px-4 py-2 bg-red-500/20 hover:bg-red-500/30
-                               border border-red-500/30 hover:border-red-500/50
-                               text-red-400 rounded-lg transition-all
+                <button class="px-4 py-2 bg-white hover:bg-red-50
+                               border border-red-300 hover:border-red-500
+                               text-red-600 rounded-lg transition-colors
                                focus:outline-none focus:ring-2 focus:ring-red-500/50"
                         aria-label="{{ t('error.close', 'Close') }}"
                         onclick="document.getElementById('error-message').remove()">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,6 @@ module.exports = {
     './app/templates/**/*.html',
     './app/static/js/**/*.js'
   ],
-  darkMode: 'class',
   theme: {
     extend: {
       fontFamily: {
@@ -18,36 +17,17 @@ module.exports = {
         },
         secondary: '#EC4899', // Pink 500
         accent: '#8B5CF6',    // Violet 500
-        background: '#0B0F19', // Darker rich blue-black
-        surface: '#111827',    // Gray 900
+        background: '#FFFFFF', // White
+        surface: '#F8FAFC',    // Slate 50
         text: {
-          primary: '#F9FAFB',
-          secondary: '#9CA3AF',
+          primary: '#0F172A',   // Slate 900
+          secondary: '#475569', // Slate 600
         },
       },
-      backgroundImage: {
-        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'hero-pattern': "url('/static/images/grid.svg')",
-      },
       animation: {
-        'shine': 'shine 1.5s infinite',
-        'gradient-text': 'gradient-text 8s ease infinite',
         'indeterminate': 'indeterminate 1.5s ease-in-out infinite',
       },
       keyframes: {
-        shine: {
-          '100%': { left: '125%' },
-        },
-        'gradient-text': {
-          '0%, 100%': {
-            'background-size': '200% 200%',
-            'background-position': 'left center'
-          },
-          '50%': {
-            'background-size': '200% 200%',
-            'background-position': 'right center'
-          },
-        },
         'indeterminate': {
           '0%': { transform: 'translateX(-100%)' },
           '100%': { transform: 'translateX(300%)' },

--- a/tests/test_dish_card.py
+++ b/tests/test_dish_card.py
@@ -59,9 +59,9 @@ def test_dish_card_renders_spiciness_indicator(app: Flask, sample_dish: Dish) ->
         # 辛さの絵文字が表示される
         assert "🌶️" in html
 
-        # 辛さレベル2なので、bg-red-500が2つ、bg-slate-600が3つ
+        # 辛さレベル2なので、bg-red-500が2つ、bg-slate-200が3つ
         assert html.count("bg-red-500") >= 2
-        assert html.count("bg-slate-600") >= 3
+        assert html.count("bg-slate-200") >= 3
 
 
 def test_dish_card_renders_sweetness_indicator(app: Flask, sample_dish: Dish) -> None:
@@ -147,14 +147,14 @@ def test_dish_card_has_correct_css_classes(app: Flask, sample_dish: Dish) -> Non
         """
         html = render_template_string(template, dish=sample_dish)
 
-        # 主要なCSSクラスが含まれる
+        # 主要なCSSクラスが含まれる（ライトモード）
         assert "dish-card" in html
-        assert "bg-surface" in html
+        assert "bg-white" in html
         assert "rounded-xl" in html
-        assert "shadow-lg" in html
-        assert "hover:shadow-xl" in html
-        assert "transition-all" in html
-        assert "border-slate-700" in html
+        assert "shadow-sm" in html
+        assert "hover:shadow-md" in html
+        assert "transition-shadow" in html
+        assert "border-slate-200" in html
         assert "hover:border-primary" in html
 
 

--- a/tests/test_error_partial.py
+++ b/tests/test_error_partial.py
@@ -108,11 +108,11 @@ def test_error_partial_has_correct_css_classes(app: Flask) -> None:
         html = render_template_string(template, message="テストエラー")
 
         assert 'id="error-message"' in html
-        assert "bg-red-500/10" in html
-        assert "border-red-500/30" in html
+        assert "bg-red-50" in html
+        assert "border-red-200" in html
         assert "rounded-xl" in html
         assert "animate-shake" in html
-        assert "text-red-400" in html
+        assert "text-red-700" in html
 
 
 def test_error_partial_renders_all_error_types(app: Flask) -> None:

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,4 +1,9 @@
-"""Tests for OpenAIProvider (GPT-4V menu analysis)."""
+"""Tests for OpenAIProvider (GPT-5.4 menu analysis).
+
+パース共通ロジックは ``test_response_parser.py`` で検証するため、
+ここでは OpenAI 固有の振る舞い（初期化・API 呼び出し形式・エラー変換）
+に絞ってテストする。
+"""
 
 from __future__ import annotations
 
@@ -8,219 +13,125 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.models.dish import Category
-from app.services.ai.base import (
-    APICallError,
-    APIKeyMissingError,
-    InvalidMenuImageError,
-)
+from app.services.ai.base import APICallError, APIKeyMissingError
+from app.services.ai.factory import AIProviderFactory
 from app.services.ai.openai_provider import OpenAIProvider
 
 
-def _build_dish_dict(name: str = "Pad Thai", number: int | None = 1) -> dict:
-    """Build a minimal valid dish dict for response fixtures."""
-    d = {
-        "original_name": name,
-        "translated_name": name,
-        "description": f"desc {name}",
-        "spiciness": 2,
-        "sweetness": 3,
-        "ingredients": ["x"],
-        "allergens": [],
-        "category": "main",
+def _dish_payload() -> dict:
+    return {
+        "dishes": [
+            {
+                "original_name": "Green Curry",
+                "translated_name": "グリーンカレー",
+                "description": "タイのグリーンカレー",
+                "spiciness": 4,
+                "sweetness": 2,
+                "ingredients": ["鶏肉", "ココナッツミルク"],
+                "allergens": [],
+                "category": "main",
+                "number": 1,
+            }
+        ]
     }
-    if number is not None:
-        d["number"] = number
-    return d
+
+
+def _mock_openai(mock_cls: MagicMock, response_text: str) -> MagicMock:
+    """Return a MagicMock OpenAI client wired to return ``response_text``."""
+    client = MagicMock()
+    mock_cls.return_value = client
+    message = MagicMock()
+    message.content = response_text
+    client.chat.completions.create.return_value = MagicMock(choices=[MagicMock(message=message)])
+    return client
 
 
 class TestOpenAIProviderInit:
-    """OpenAIProvider initialization."""
-
-    def test_initialization_with_api_key(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        assert provider.api_key == "sk-test-xyz"
+    def test_initialization_sets_fields(self):
+        provider = OpenAIProvider(api_key="sk-test", language="ja")
+        assert provider.api_key == "sk-test"
+        assert provider.language == "ja"
         assert provider.client is not None
 
-    def test_initialization_without_api_key_raises(self):
+    def test_default_language_is_en(self):
+        assert OpenAIProvider(api_key="sk-test").language == "en"
+
+    def test_empty_api_key_raises(self):
         with pytest.raises(APIKeyMissingError, match="API key is required"):
             OpenAIProvider(api_key="")
 
-    def test_name_property_returns_openai(self):
+    def test_name_is_openai(self):
         with patch.dict(os.environ, {}, clear=True):
-            provider = OpenAIProvider(api_key="sk-test-xyz")
-            assert provider.name == "openai"
-
-    def test_default_language(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        assert provider.language == "en"
-
-    def test_custom_language(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz", language="ja")
-        assert provider.language == "ja"
+            assert OpenAIProvider(api_key="sk-test").name == "openai"
 
 
 class TestOpenAIProviderPrompt:
-    """Prompt construction."""
-
-    def test_build_prompt_includes_required_fields(self):
-        with patch.dict(os.environ, {}, clear=True):
-            provider = OpenAIProvider(api_key="sk-test-xyz")
-            prompt = provider._build_prompt()
-
-            assert "JSON" in prompt
-            assert "original_name" in prompt
-            assert "translated_name" in prompt
-            assert "spiciness" in prompt
-            assert "sweetness" in prompt
-            assert "ingredients" in prompt
-            assert "allergens" in prompt
-            assert "category" in prompt
-
-
-class TestOpenAIProviderParseResponse:
-    """Response parsing."""
-
-    def test_parse_valid_json(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        payload = {"dishes": [_build_dish_dict("Pad Thai", 1)]}
-        dishes = provider._parse_response(json.dumps(payload))
-
-        assert len(dishes) == 1
-        assert dishes[0].original_name == "Pad Thai"
-        assert dishes[0].category == Category.MAIN
-
-    def test_parse_markdown_fenced_json(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        payload = {"dishes": [_build_dish_dict("Tom Yum", 1)]}
-        fenced = f"```json\n{json.dumps(payload)}\n```"
-        dishes = provider._parse_response(fenced)
-        assert len(dishes) == 1
-        assert dishes[0].original_name == "Tom Yum"
-
-        fenced2 = f"```\n{json.dumps(payload)}\n```"
-        dishes2 = provider._parse_response(fenced2)
-        assert len(dishes2) == 1
-
-    def test_parse_invalid_json_raises(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        with pytest.raises(APICallError, match="Failed to parse JSON"):
-            provider._parse_response("not json")
-
-    def test_parse_missing_dishes_key_raises(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        with pytest.raises(APICallError, match="'dishes' key"):
-            provider._parse_response(json.dumps({"menu": []}))
-
-    def test_parse_empty_dishes_raises_invalid_menu(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        with pytest.raises(InvalidMenuImageError, match="Could not detect menu"):
-            provider._parse_response(json.dumps({"dishes": []}))
-
-    def test_parse_skips_invalid_dishes(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        payload = {
-            "dishes": [
-                {"original_name": "Bad"},  # missing required fields
-                _build_dish_dict("Good", 1),
-            ]
-        }
-        dishes = provider._parse_response(json.dumps(payload))
-        assert len(dishes) == 1
-        assert dishes[0].original_name == "Good"
-
-    def test_parse_reassigns_non_sequential_numbers(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        payload = {
-            "dishes": [
-                _build_dish_dict("A", 1),
-                _build_dish_dict("C", 3),  # gap at 2
-                _build_dish_dict("D", 4),
-            ]
-        }
-        dishes = provider._parse_response(json.dumps(payload))
-        assert [d.number for d in dishes] == [1, 2, 3]
-        assert [d.original_name for d in dishes] == ["A", "C", "D"]
-
-    def test_parse_json_array_not_dict_raises(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
-        with pytest.raises(APICallError, match="'dishes' key"):
-            provider._parse_response(json.dumps(["not", "a", "dict"]))
+    def test_prompt_includes_required_fields(self):
+        prompt = OpenAIProvider(api_key="sk-test")._build_prompt()
+        for key in ("JSON", "original_name", "translated_name", "spiciness",
+                    "sweetness", "ingredients", "allergens", "category", "number"):
+            assert key in prompt
 
 
 class TestOpenAIProviderAnalyzeMenu:
-    """analyze_menu integration with mocked OpenAI client."""
-
-    def test_image_size_exceeds_limit_raises(self):
-        provider = OpenAIProvider(api_key="sk-test-xyz")
+    def test_rejects_oversized_image(self):
+        provider = OpenAIProvider(api_key="sk-test")
         big = b"x" * (provider.MAX_IMAGE_SIZE + 1)
-        with pytest.raises(APICallError, match="Image size .* exceeds maximum"):
+        with pytest.raises(APICallError, match="exceeds maximum"):
             provider.analyze_menu(big, "image/jpeg")
 
     @patch("app.services.ai.openai_provider.OpenAI")
-    def test_analyze_menu_success(self, mock_openai_class):
-        payload = {"dishes": [_build_dish_dict("Green Curry", 1)]}
-        mock_client = MagicMock()
-        mock_openai_class.return_value = mock_client
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = json.dumps(payload)
-        mock_client.chat.completions.create.return_value = mock_response
+    def test_success_returns_analysis_result(self, mock_openai_class):
+        _mock_openai(mock_openai_class, json.dumps(_dish_payload()))
 
-        provider = OpenAIProvider(api_key="sk-test-xyz")
+        provider = OpenAIProvider(api_key="sk-test")
         result = provider.analyze_menu(b"fake image", "image/jpeg")
 
         assert result.provider == "openai"
-        assert len(result.dishes) == 1
-        assert result.dishes[0].original_name == "Green Curry"
         assert result.processing_time > 0
-
-        # Verify call signature
-        mock_client.chat.completions.create.assert_called_once()
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs["model"] == OpenAIProvider.MODEL
-        # Verify image is embedded as data URL with correct mime type
-        messages = call_kwargs["messages"]
-        content_blocks = messages[0]["content"]
-        image_block = next(b for b in content_blocks if b["type"] == "image_url")
-        assert image_block["image_url"]["url"].startswith("data:image/jpeg;base64,")
+        assert [d.original_name for d in result.dishes] == ["Green Curry"]
 
     @patch("app.services.ai.openai_provider.OpenAI")
-    def test_analyze_menu_wraps_openai_api_error(self, mock_openai_class):
+    def test_sends_data_url_with_correct_mime_and_model(self, mock_openai_class):
+        client = _mock_openai(mock_openai_class, json.dumps(_dish_payload()))
+
+        OpenAIProvider(api_key="sk-test").analyze_menu(b"fake", "image/png")
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == OpenAIProvider.MODEL
+        assert kwargs["max_tokens"] == OpenAIProvider.MAX_TOKENS
+        image_block = next(
+            b for b in kwargs["messages"][0]["content"] if b["type"] == "image_url"
+        )
+        assert image_block["image_url"]["url"].startswith("data:image/png;base64,")
+
+    @patch("app.services.ai.openai_provider.OpenAI")
+    def test_wraps_openai_api_error(self, mock_openai_class):
         from openai import APIError
 
-        mock_client = MagicMock()
-        mock_openai_class.return_value = mock_client
-        mock_client.chat.completions.create.side_effect = APIError(
+        client = MagicMock()
+        mock_openai_class.return_value = client
+        client.chat.completions.create.side_effect = APIError(
             message="boom", request=MagicMock(), body=None
         )
 
-        provider = OpenAIProvider(api_key="sk-test-xyz")
         with pytest.raises(APICallError, match="OpenAI API call failed"):
-            provider.analyze_menu(b"fake", "image/jpeg")
+            OpenAIProvider(api_key="sk-test").analyze_menu(b"fake", "image/jpeg")
 
     @patch("app.services.ai.openai_provider.OpenAI")
-    def test_analyze_menu_wraps_unexpected_error(self, mock_openai_class):
-        mock_client = MagicMock()
-        mock_openai_class.return_value = mock_client
-        mock_client.chat.completions.create.side_effect = RuntimeError("unexpected")
+    def test_wraps_unexpected_error(self, mock_openai_class):
+        client = MagicMock()
+        mock_openai_class.return_value = client
+        client.chat.completions.create.side_effect = RuntimeError("unexpected")
 
-        provider = OpenAIProvider(api_key="sk-test-xyz")
         with pytest.raises(APICallError, match="Unexpected error"):
-            provider.analyze_menu(b"fake", "image/jpeg")
+            OpenAIProvider(api_key="sk-test").analyze_menu(b"fake", "image/jpeg")
 
 
 class TestOpenAIProviderFactoryRegistration:
-    """Factory integration."""
-
-    def test_factory_creates_openai_provider(self):
-        from app.services.ai.factory import AIProviderFactory
-
-        provider = AIProviderFactory.create(api_key="sk-test-xyz", provider_name="openai")
+    def test_factory_creates_openai(self):
+        provider = AIProviderFactory.create(api_key="sk-test", provider_name="openai")
         assert isinstance(provider, OpenAIProvider)
-        assert provider.name == "openai"
 
     def test_openai_in_available_providers(self):
-        from app.services.ai.factory import AIProviderFactory
-
         assert "openai" in AIProviderFactory.available_providers()

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,0 +1,226 @@
+"""Tests for OpenAIProvider (GPT-4V menu analysis)."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models.dish import Category
+from app.services.ai.base import (
+    APICallError,
+    APIKeyMissingError,
+    InvalidMenuImageError,
+)
+from app.services.ai.openai_provider import OpenAIProvider
+
+
+def _build_dish_dict(name: str = "Pad Thai", number: int | None = 1) -> dict:
+    """Build a minimal valid dish dict for response fixtures."""
+    d = {
+        "original_name": name,
+        "translated_name": name,
+        "description": f"desc {name}",
+        "spiciness": 2,
+        "sweetness": 3,
+        "ingredients": ["x"],
+        "allergens": [],
+        "category": "main",
+    }
+    if number is not None:
+        d["number"] = number
+    return d
+
+
+class TestOpenAIProviderInit:
+    """OpenAIProvider initialization."""
+
+    def test_initialization_with_api_key(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        assert provider.api_key == "sk-test-xyz"
+        assert provider.client is not None
+
+    def test_initialization_without_api_key_raises(self):
+        with pytest.raises(APIKeyMissingError, match="API key is required"):
+            OpenAIProvider(api_key="")
+
+    def test_name_property_returns_openai(self):
+        with patch.dict(os.environ, {}, clear=True):
+            provider = OpenAIProvider(api_key="sk-test-xyz")
+            assert provider.name == "openai"
+
+    def test_default_language(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        assert provider.language == "en"
+
+    def test_custom_language(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz", language="ja")
+        assert provider.language == "ja"
+
+
+class TestOpenAIProviderPrompt:
+    """Prompt construction."""
+
+    def test_build_prompt_includes_required_fields(self):
+        with patch.dict(os.environ, {}, clear=True):
+            provider = OpenAIProvider(api_key="sk-test-xyz")
+            prompt = provider._build_prompt()
+
+            assert "JSON" in prompt
+            assert "original_name" in prompt
+            assert "translated_name" in prompt
+            assert "spiciness" in prompt
+            assert "sweetness" in prompt
+            assert "ingredients" in prompt
+            assert "allergens" in prompt
+            assert "category" in prompt
+
+
+class TestOpenAIProviderParseResponse:
+    """Response parsing."""
+
+    def test_parse_valid_json(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        payload = {"dishes": [_build_dish_dict("Pad Thai", 1)]}
+        dishes = provider._parse_response(json.dumps(payload))
+
+        assert len(dishes) == 1
+        assert dishes[0].original_name == "Pad Thai"
+        assert dishes[0].category == Category.MAIN
+
+    def test_parse_markdown_fenced_json(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        payload = {"dishes": [_build_dish_dict("Tom Yum", 1)]}
+        fenced = f"```json\n{json.dumps(payload)}\n```"
+        dishes = provider._parse_response(fenced)
+        assert len(dishes) == 1
+        assert dishes[0].original_name == "Tom Yum"
+
+        fenced2 = f"```\n{json.dumps(payload)}\n```"
+        dishes2 = provider._parse_response(fenced2)
+        assert len(dishes2) == 1
+
+    def test_parse_invalid_json_raises(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        with pytest.raises(APICallError, match="Failed to parse JSON"):
+            provider._parse_response("not json")
+
+    def test_parse_missing_dishes_key_raises(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        with pytest.raises(APICallError, match="'dishes' key"):
+            provider._parse_response(json.dumps({"menu": []}))
+
+    def test_parse_empty_dishes_raises_invalid_menu(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        with pytest.raises(InvalidMenuImageError, match="Could not detect menu"):
+            provider._parse_response(json.dumps({"dishes": []}))
+
+    def test_parse_skips_invalid_dishes(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        payload = {
+            "dishes": [
+                {"original_name": "Bad"},  # missing required fields
+                _build_dish_dict("Good", 1),
+            ]
+        }
+        dishes = provider._parse_response(json.dumps(payload))
+        assert len(dishes) == 1
+        assert dishes[0].original_name == "Good"
+
+    def test_parse_reassigns_non_sequential_numbers(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        payload = {
+            "dishes": [
+                _build_dish_dict("A", 1),
+                _build_dish_dict("C", 3),  # gap at 2
+                _build_dish_dict("D", 4),
+            ]
+        }
+        dishes = provider._parse_response(json.dumps(payload))
+        assert [d.number for d in dishes] == [1, 2, 3]
+        assert [d.original_name for d in dishes] == ["A", "C", "D"]
+
+    def test_parse_json_array_not_dict_raises(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        with pytest.raises(APICallError, match="'dishes' key"):
+            provider._parse_response(json.dumps(["not", "a", "dict"]))
+
+
+class TestOpenAIProviderAnalyzeMenu:
+    """analyze_menu integration with mocked OpenAI client."""
+
+    def test_image_size_exceeds_limit_raises(self):
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        big = b"x" * (provider.MAX_IMAGE_SIZE + 1)
+        with pytest.raises(APICallError, match="Image size .* exceeds maximum"):
+            provider.analyze_menu(big, "image/jpeg")
+
+    @patch("app.services.ai.openai_provider.OpenAI")
+    def test_analyze_menu_success(self, mock_openai_class):
+        payload = {"dishes": [_build_dish_dict("Green Curry", 1)]}
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(payload)
+        mock_client.chat.completions.create.return_value = mock_response
+
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        result = provider.analyze_menu(b"fake image", "image/jpeg")
+
+        assert result.provider == "openai"
+        assert len(result.dishes) == 1
+        assert result.dishes[0].original_name == "Green Curry"
+        assert result.processing_time > 0
+
+        # Verify call signature
+        mock_client.chat.completions.create.assert_called_once()
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == OpenAIProvider.MODEL
+        # Verify image is embedded as data URL with correct mime type
+        messages = call_kwargs["messages"]
+        content_blocks = messages[0]["content"]
+        image_block = next(b for b in content_blocks if b["type"] == "image_url")
+        assert image_block["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    @patch("app.services.ai.openai_provider.OpenAI")
+    def test_analyze_menu_wraps_openai_api_error(self, mock_openai_class):
+        from openai import APIError
+
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = APIError(
+            message="boom", request=MagicMock(), body=None
+        )
+
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        with pytest.raises(APICallError, match="OpenAI API call failed"):
+            provider.analyze_menu(b"fake", "image/jpeg")
+
+    @patch("app.services.ai.openai_provider.OpenAI")
+    def test_analyze_menu_wraps_unexpected_error(self, mock_openai_class):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = RuntimeError("unexpected")
+
+        provider = OpenAIProvider(api_key="sk-test-xyz")
+        with pytest.raises(APICallError, match="Unexpected error"):
+            provider.analyze_menu(b"fake", "image/jpeg")
+
+
+class TestOpenAIProviderFactoryRegistration:
+    """Factory integration."""
+
+    def test_factory_creates_openai_provider(self):
+        from app.services.ai.factory import AIProviderFactory
+
+        provider = AIProviderFactory.create(api_key="sk-test-xyz", provider_name="openai")
+        assert isinstance(provider, OpenAIProvider)
+        assert provider.name == "openai"
+
+    def test_openai_in_available_providers(self):
+        from app.services.ai.factory import AIProviderFactory
+
+        assert "openai" in AIProviderFactory.available_providers()

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -1,0 +1,97 @@
+"""Tests for the shared AI response parser."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.models.dish import Category
+from app.services.ai.base import APICallError, InvalidMenuImageError
+from app.services.ai.response_parser import parse_dishes
+
+
+def _dish(name: str = "Pad Thai", number: int | None = 1) -> dict:
+    d = {
+        "original_name": name,
+        "translated_name": name,
+        "description": f"desc {name}",
+        "spiciness": 2,
+        "sweetness": 3,
+        "ingredients": ["x"],
+        "allergens": [],
+        "category": "main",
+    }
+    if number is not None:
+        d["number"] = number
+    return d
+
+
+class TestParseDishesHappyPath:
+    def test_plain_json(self):
+        dishes = parse_dishes(json.dumps({"dishes": [_dish("Pad Thai", 1)]}))
+        assert len(dishes) == 1
+        assert dishes[0].original_name == "Pad Thai"
+        assert dishes[0].category == Category.MAIN
+
+    def test_json_fenced(self):
+        body = json.dumps({"dishes": [_dish("Tom Yum", 1)]})
+        assert len(parse_dishes(f"```json\n{body}\n```")) == 1
+        assert len(parse_dishes(f"```\n{body}\n```")) == 1
+
+
+class TestParseDishesErrors:
+    def test_invalid_json_raises(self):
+        with pytest.raises(APICallError, match="Failed to parse JSON"):
+            parse_dishes("not json")
+
+    def test_missing_dishes_key_raises(self):
+        with pytest.raises(APICallError, match="'dishes' key"):
+            parse_dishes(json.dumps({"menu": []}))
+
+    def test_array_root_raises(self):
+        with pytest.raises(APICallError, match="'dishes' key"):
+            parse_dishes(json.dumps(["not", "a", "dict"]))
+
+    def test_all_dishes_invalid_raises_invalid_menu(self):
+        with pytest.raises(InvalidMenuImageError, match="Could not detect menu"):
+            parse_dishes(json.dumps({"dishes": []}))
+
+
+class TestParseDishesResilience:
+    def test_skips_invalid_dishes(self):
+        payload = {"dishes": [{"original_name": "Bad"}, _dish("Good", 1)]}
+        dishes = parse_dishes(json.dumps(payload))
+        assert [d.original_name for d in dishes] == ["Good"]
+
+
+class TestParseDishesNumbering:
+    def test_sorts_by_number_when_sequential(self):
+        payload = {
+            "dishes": [_dish("Third", 3), _dish("First", 1), _dish("Second", 2)]
+        }
+        dishes = parse_dishes(json.dumps(payload))
+        assert [d.number for d in dishes] == [1, 2, 3]
+        assert [d.original_name for d in dishes] == ["First", "Second", "Third"]
+
+    def test_reassigns_on_missing_number(self):
+        payload = {
+            "dishes": [_dish("A", 1), _dish("B", None), _dish("C", 3)]
+        }
+        dishes = parse_dishes(json.dumps(payload))
+        assert [d.number for d in dishes] == [1, 2, 3]
+
+    def test_reassigns_on_duplicate(self):
+        payload = {
+            "dishes": [_dish("A", 1), _dish("B", 1), _dish("C", 2)]
+        }
+        dishes = parse_dishes(json.dumps(payload))
+        assert [d.number for d in dishes] == [1, 2, 3]
+
+    def test_reassigns_on_non_sequential_gap(self):
+        payload = {
+            "dishes": [_dish("A", 1), _dish("C", 3), _dish("D", 4)]
+        }
+        dishes = parse_dishes(json.dumps(payload))
+        assert [d.number for d in dishes] == [1, 2, 3]
+        assert [d.original_name for d in dishes] == ["A", "C", "D"]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -54,8 +54,8 @@ def test_base_template_has_required_elements(app):
         assert "js/app.js" in rendered
 
 
-def test_base_template_has_dark_mode(app):
-    """Test that base template has dark mode class."""
+def test_base_template_is_light_mode(app):
+    """Test that base template does not have dark mode class."""
     with app.test_request_context():
         from flask import render_template_string
 
@@ -65,7 +65,7 @@ def test_base_template_has_dark_mode(app):
         """
         rendered = render_template_string(template)
 
-        assert 'class="dark"' in rendered
+        assert 'class="dark"' not in rendered
 
 
 def test_base_template_has_flexbox_layout(app):
@@ -142,7 +142,6 @@ def test_loading_component_renders(app):
 
         # Check for spinner container
         assert "loading-container" in rendered
-        assert "animate-pulse" in rendered
 
         # Check for spinner SVG
         assert "animate-spin" in rendered
@@ -166,7 +165,6 @@ def test_loading_component_has_required_animations(app):
         rendered = render_template("components/loading.html")
 
         # Check for Tailwind animations
-        assert "animate-pulse" in rendered
         assert "animate-spin" in rendered
 
         # Check for custom indeterminate animation


### PR DESCRIPTION
## Summary

このPRには **2つの独立した変更** が含まれる（同一ブランチに後追いコミットされたため）:

1. **OpenAI GPT-5.4 ビジョンプロバイダーの追加** (#53)
2. **UIをシンプルなライトモードに変更** (#57)

Closes #53
Closes #57

---

## 1. OpenAIプロバイダー追加 (#53)

- `OpenAIProvider` を `AIProvider` 契約で実装（**GPT-5.4**, data URL 形式で画像送信）
- `AIProviderFactory` に `"openai"` を登録 — 既存ルート層は無変更で `provider_name="openai"` 指定だけで切替可能
- 単体テスト 20 件追加（カバレッジ 97%, 要件 80% をクリア）

### モデル選定
2026年3月リリースの **GPT-5.4** を採用。
- 画像理解・チャート推論・レイアウト把握が強化（レストランメニューの認識に有利）
- 10Mピクセル超の画像も圧縮不要
- 1Mトークンのコンテキストウィンドウ
- 参考: [Introducing GPT-5.4](https://openai.com/index/introducing-gpt-5-4/)

### 実装詳細
- 画像送信: Base64 エンコード後 `data:{mime_type};base64,...` の data URL で `chat.completions` に渡す
- レスポンス形式: Claude と同じ `{"dishes": [...]}` JSON → `Dish` モデルへ変換
- エラーハンドリング: `openai.APIError` → `APICallError`, 画像サイズ超過（10MB）もガード
- 料理番号の正規化ロジック（欠損・重複・非連続）は Claude と同仕様

---

## 2. UIライトモード化 (#57)

ダークモード＋AI ツール風グラデーション/グロー/Shineを廃止し、シンプルで落ち着いた白ベース UI に変更。

### 変更内容
- Tailwindトークンを白ベースに変更（`background`, `surface`, `text`）
- `class="dark"`、背景 blur orb、glow/shine/gradient-text アニメーションを削除
- ボタン・モーダルヘッダー・ロゴのグラデーションを単色プライマリに置換
- カード・スケルトン・エラー表示をライト配色に統一（`bg-white`, `border-slate-200`, `text-slate-700` 等）
- Tailwind config から未使用キーフレーム（shine, gradient-text）を削除
- 既存の振る舞いテストを新ライトテーマに合わせて更新

### 影響範囲
- `tailwind.config.js`, `app/static/css/app.css`（再ビルド）
- テンプレート 11 ファイル（base, index, components/*, partials/*）
- テスト 3 ファイル（test_dish_card, test_error_partial, test_templates）

---

## Test plan

- [x] 単体テスト: `pytest tests/test_openai_provider.py -v` (20 passed)
- [x] 全体テスト: `pytest` (268 passed, 失敗 0)
- [x] カバレッジ: `openai_provider.py` 97%
- [ ] 実 API 動作確認: ユーザーが OpenAI API キーを入力して E2E で検証
- [ ] ブラウザ目視確認: `python run.py` でライトモード UI が崩れていないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)